### PR TITLE
feat: add sample for serverless

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,6 @@
+Diagnostics:
+  Suppress: performance-avoid-endl
+
 CompileFlags:
   Add: [-std=c++17, -I/usr/include/c++/13, -I/usr/include/x86_64-linux-gnu/c++/13]
+

--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  Add: [-I/usr/include/c++/13, -I/usr/include/x86_64-linux-gnu/c++/13]

--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,2 @@
 CompileFlags:
-  Add: [-I/usr/include/c++/13, -I/usr/include/x86_64-linux-gnu/c++/13]
+  Add: [-std=c++17, -I/usr/include/c++/13, -I/usr/include/x86_64-linux-gnu/c++/13]

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lib/.jiftools_installed_ver
 *.snapshot
 *.elf
 *.metadata
+.cache
 
 lib/node
 

--- a/junction/control/serverless.cc
+++ b/junction/control/serverless.cc
@@ -486,8 +486,10 @@ void ChannelWorker(rt::TCPConn& c) {
 
 void ChannelServer(rt::TCPQueue& q) {
   while (true) {
+    LOG(INFO) << "waiting for client connection...";
     Status<rt::TCPConn> c = q.Accept();
     if (!c) panic("couldn't accept a connection");
+    LOG(INFO) << "client connected, spawning a channel worker";
     rt::Spawn([c = std::move(*c)] mutable { ChannelWorker(c); });
   }
 }

--- a/junction/control/serverless.cc
+++ b/junction/control/serverless.cc
@@ -22,7 +22,7 @@ rt::SharedMutex lock_;
 std::unordered_map<int, std::shared_ptr<FunctionInode>> channels_;
 
 std::string from_byte_span(std::span<const std::byte> byte_span) {
-  return std::string(reinterpret_cast<const char *>(byte_span.data()),
+  return std::string(reinterpret_cast<const char*>(byte_span.data()),
                      byte_span.size());
 }
 
@@ -155,7 +155,7 @@ class FunctionChannel {
   }
 
   template <class Archive>
-  void serialize(Archive &ar) {
+  void serialize(Archive& ar) {
     ar(latencies_us_);
   }
 
@@ -174,13 +174,13 @@ class FunctionChannel {
 
   friend class FunctionChannelFile;
 
-  void Attach(PollSource *p) {
+  void Attach(PollSource* p) {
     rt::SpinGuard g(lock_);
     pollers_.Attach(p);
     if (request_.size()) p->Set(kPollIn);
   }
 
-  void Detach(PollSource *p) {
+  void Detach(PollSource* p) {
     rt::SpinGuard g(lock_);
     pollers_.Detach(p);
   }
@@ -206,13 +206,13 @@ class FunctionInode : public Inode {
       uint32_t flags, FileMode mode,
       std::shared_ptr<DirectoryEntry> dent) override;
 
-  Status<void> GetStats(struct stat *buf) const override {
+  Status<void> GetStats(struct stat* buf) const override {
     InodeToStats(*this, buf);
     return {};
   }
 
   template <class Archive>
-  void save(Archive &ar) const {
+  void save(Archive& ar) const {
     BUG_ON(chan_.in_progress());
     ar(id_, get_inum());
     ar(cereal::base_class<Inode>(this));
@@ -220,8 +220,8 @@ class FunctionInode : public Inode {
   }
 
   template <class Archive>
-  static void load_and_construct(Archive &ar,
-                                 cereal::construct<FunctionInode> &construct) {
+  static void load_and_construct(Archive& ar,
+                                 cereal::construct<FunctionInode>& construct) {
     int id;
     ino_t inum;
     ar(id, inum);
@@ -233,8 +233,8 @@ class FunctionInode : public Inode {
         std::static_pointer_cast<FunctionInode>(construct->get_this());
   }
 
-  [[nodiscard]] FunctionChannel &get_chan() { return chan_; }
-  [[nodiscard]] const FunctionChannel &get_chan() const { return chan_; }
+  [[nodiscard]] FunctionChannel& get_chan() { return chan_; }
+  [[nodiscard]] const FunctionChannel& get_chan() const { return chan_; }
 
  private:
   int id_;
@@ -247,42 +247,41 @@ class FunctionChannelFile : public SeekableFile {
                       std::shared_ptr<DirectoryEntry> dent) noexcept
       : SeekableFile(FileType::kNormal, flags & kFlagNonblock, mode,
                      std::move(dent)) {
-    FunctionInode &ino = fast_cast<FunctionInode &>(get_inode_ref());
+    FunctionInode& ino = fast_cast<FunctionInode&>(get_inode_ref());
     ino.get_chan().Attach(&get_poll_source());
   }
 
   ~FunctionChannelFile() override {
-    FunctionInode &ino = fast_cast<FunctionInode &>(get_inode_ref());
+    FunctionInode& ino = fast_cast<FunctionInode&>(get_inode_ref());
     ino.get_chan().Detach(&get_poll_source());
   }
 
   Status<size_t> Read(std::span<std::byte> buf,
-                      [[maybe_unused]] off_t *off) override {
-    FunctionInode &ino = fast_cast<FunctionInode &>(get_inode_ref());
+                      [[maybe_unused]] off_t* off) override {
+    FunctionInode& ino = fast_cast<FunctionInode&>(get_inode_ref());
     return ino.get_chan().Read(buf, is_nonblocking());
   }
 
   Status<size_t> Write(std::span<const std::byte> buf,
-                       [[maybe_unused]] off_t *off) override {
-    FunctionInode &ino = fast_cast<FunctionInode &>(get_inode_ref());
+                       [[maybe_unused]] off_t* off) override {
+    FunctionInode& ino = fast_cast<FunctionInode&>(get_inode_ref());
     return ino.get_chan().Write(buf);
   }
 
   [[nodiscard]] Status<size_t> get_input_bytes() const override {
-    const FunctionInode &ino =
-        fast_cast<const FunctionInode &>(get_inode_ref());
+    const FunctionInode& ino = fast_cast<const FunctionInode&>(get_inode_ref());
     return ino.get_chan().get_input_bytes();
   }
 
   template <class Archive>
-  void save(Archive &ar) const {
+  void save(Archive& ar) const {
     ar(get_mode(), get_dent());
     ar(cereal::base_class<SeekableFile>(this));
   }
 
   template <class Archive>
   static void load_and_construct(
-      Archive &ar, cereal::construct<FunctionChannelFile> &construct) {
+      Archive& ar, cereal::construct<FunctionChannelFile>& construct) {
     FileMode mode;
     std::shared_ptr<DirectoryEntry> dent;
     ar(mode, dent);
@@ -304,16 +303,16 @@ std::shared_ptr<FunctionInode> get_channel(int chan) {
 }
 
 Status<void> SetupServerlessChannel(int chan) {
-  FSRoot &fs = FSRoot::GetGlobalRoot();
+  FSRoot& fs = FSRoot::GetGlobalRoot();
   rt::ScopedLock g(lock_);
 
   if (channels_.count(chan) > 0) return MakeError(EEXIST);
 
   Status<std::shared_ptr<Inode>> srvdir = LookupInode(fs, "/serverless");
-  IDir *dir;
+  IDir* dir;
   if (srvdir) {
     assert((*srvdir)->is_dir());
-    dir = static_cast<IDir *>(srvdir->get());
+    dir = static_cast<IDir*>(srvdir->get());
   } else {
     dir = memfs::MkFolder(*fs.get_root().get(), "serverless").get();
   }
@@ -325,7 +324,7 @@ Status<void> SetupServerlessChannel(int chan) {
   return {};
 }
 
-void PrintTimes(const std::vector<uint64_t> &times, std::string_view name) {
+void PrintTimes(const std::vector<uint64_t>& times, std::string_view name) {
   std::stringstream ss;
   ss << "DATA  {\"times\": [";
   for (size_t i = 0; i < times.size(); i++) {
@@ -360,7 +359,7 @@ void RunRestored(std::shared_ptr<Process> proc, int chan_id,
     syscall_exit(-1);
   }
 
-  FunctionChannel &chan = fino->get_chan();
+  FunctionChannel& chan = fino->get_chan();
 
 #ifdef FUNCTION_PROFILING
   std::vector<std::pair<std::string, PerfEventMon>> evmons;
@@ -416,7 +415,7 @@ void WarmupAndSnapshot(std::shared_ptr<Process> proc, int chan_id,
     syscall_exit(-1);
   }
 
-  FunctionChannel &chan = fino->get_chan();
+  FunctionChannel& chan = fino->get_chan();
 
   for (size_t i = 0; i < 10; i++) chan.DoRequest(std::string{arg});
 
@@ -454,10 +453,10 @@ pid_t GetLastBlockedTid(int chan) {
   return fino->get_chan().get_last_blocked_tid();
 }
 
-void ChannelWorker(rt::TCPConn &c) {
+void ChannelWorker(rt::TCPConn& c) {
   std::vector<std::byte> data;
   std::shared_ptr<FunctionInode> fino = get_channel(0);
-  FunctionChannel &chan = fino->get_chan();
+  FunctionChannel& chan = fino->get_chan();
 
   while (true) {
     size_t nbytes;
@@ -473,7 +472,7 @@ void ChannelWorker(rt::TCPConn &c) {
     ret = ReadFull(c, {data.data(), nbytes});
     if (unlikely(!ret)) break;
 
-    std::string req(reinterpret_cast<const char *>(data.data()), nbytes);
+    std::string req(reinterpret_cast<const char*>(data.data()), nbytes);
     std::string res = chan.DoRequest(std::move(req));
 
     nbytes = res.size();
@@ -485,7 +484,7 @@ void ChannelWorker(rt::TCPConn &c) {
   }
 }
 
-void ChannelServer(rt::TCPQueue &q) {
+void ChannelServer(rt::TCPQueue& q) {
   while (true) {
     Status<rt::TCPConn> c = q.Accept();
     if (!c) panic("couldn't accept a connection");
@@ -496,6 +495,7 @@ void ChannelServer(rt::TCPQueue &q) {
 Status<void> InitChannelClient() {
   Status<rt::TCPQueue> q = rt::TCPQueue::Listen({0, kChannelPort}, 4096);
   if (!q) return MakeError(q);
+  LOG(INFO) << "started channel client on port " << kChannelPort;
 
   rt::Spawn([q = std::move(*q)] mutable { ChannelServer(q); });
   return {};

--- a/junction/samples/CMakeLists.txt
+++ b/junction/samples/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(netbench_udp)
 add_subdirectory(netperf_tcp)
 add_subdirectory(tcp)
 add_subdirectory(udp)
+add_subdirectory(serverless)
 
 if(SNAPSHOT_SAMPLES)
   add_subdirectory(cereal)

--- a/junction/samples/serverless/CMakeLists.txt
+++ b/junction/samples/serverless/CMakeLists.txt
@@ -25,3 +25,6 @@ file(WRITE ${caladan_function_config_path} ${caladan_function_config})
 add_executable(function 
     function.cc
 )
+
+# client
+add_executable(client client.cc)

--- a/junction/samples/serverless/CMakeLists.txt
+++ b/junction/samples/serverless/CMakeLists.txt
@@ -16,10 +16,20 @@ set(caladan_function_config
 ${caladan_config_common}"
 )
 
+set(caladan_client_config
+"host_addr 192.168.127.5
+${caladan_config_common}"
+)
+
 set(caladan_function_config_path
     ${CMAKE_CURRENT_BINARY_DIR}/caladan_function.config
 )
 file(WRITE ${caladan_function_config_path} ${caladan_function_config})
+
+set(caladan_client_config_path
+    ${CMAKE_CURRENT_BINARY_DIR}/caladan_client.config
+)
+file(WRITE ${caladan_client_config_path} ${caladan_client_config})
 
 # function
 add_executable(function 

--- a/junction/samples/serverless/CMakeLists.txt
+++ b/junction/samples/serverless/CMakeLists.txt
@@ -21,7 +21,7 @@ ${caladan_config_common}"
 set(caladan_function_config_path
     ${CMAKE_CURRENT_BINARY_DIR}/caladan_function.config
 )
-file(WRITE ${caldan_function_config_path} ${caladan_function_config})
+file(WRITE ${caladan_function_config_path} ${caladan_function_config})
 
 # function
 add_executable(function 

--- a/junction/samples/serverless/CMakeLists.txt
+++ b/junction/samples/serverless/CMakeLists.txt
@@ -1,0 +1,29 @@
+message(STATUS "Building junction sample: serverless")
+
+# Generate test configurations
+set(caladan_config_common
+"host_netmask 255.255.255.0
+host_gateway 192.168.127.1
+runtime_kthreads 1
+runtime_spinning_kthreads 0
+runtime_guaranteed_kthreads 1
+runtime_priority lc
+runtime_quantum_us 0
+enable_directpath 1
+host_mtu 9000"
+)
+
+set(caladan_function_config
+"host_addr 192.168.127.7
+${caladan_config_common}"
+)
+
+set(caladan_function_config_path
+    ${CMAKE_CURRENT_BINARY_DIR}/caladan_function.config
+)
+file(WRITE ${caldan_function_config_path} ${caladan_function_config})
+
+# function
+add_executable(function 
+    function.cc
+)

--- a/junction/samples/serverless/CMakeLists.txt
+++ b/junction/samples/serverless/CMakeLists.txt
@@ -6,11 +6,9 @@ set(caladan_config_common
 host_gateway 192.168.127.1
 runtime_kthreads 1
 runtime_spinning_kthreads 0
-runtime_guaranteed_kthreads 1
+runtime_guaranteed_kthreads 0
 runtime_priority lc
-runtime_quantum_us 0
-enable_directpath 1
-host_mtu 9000"
+runtime_quantum_us 0"
 )
 
 set(caladan_function_config

--- a/junction/samples/serverless/README.md
+++ b/junction/samples/serverless/README.md
@@ -5,5 +5,5 @@
 ### Function
 
 ```bash
-./build/junction/junction_run ./build/junction/samples/serverless/caladan_function.config --function_args warmup_data --keep_alive -- ./build/junction/samples/serverless/function
+./build/junction/junction_run ./build/junction/samples/serverless/caladan_function.config --function_arg warmup_data --keep_alive -- ./build/junction/samples/serverless/function
 ```

--- a/junction/samples/serverless/README.md
+++ b/junction/samples/serverless/README.md
@@ -1,0 +1,9 @@
+# Serverless
+
+## Junction
+
+### Function
+
+```bash
+./build/junction/junction_run ./build/junction/samples/serverless/caladan_function.config --function_args warmup_data --keep_alive -- ./build/junction/samples/serverless/function
+```

--- a/junction/samples/serverless/README.md
+++ b/junction/samples/serverless/README.md
@@ -4,7 +4,20 @@
 
 ### Function
 
+This will start the serverless function.
+
 ```bash
 cd ./build/junction
 ./junction_run ./samples/serverless/caladan_function.config --function_arg warmup_data --keep_alive -- ./samples/serverless/function
 ```
+
+### Client
+
+Open a new terminal and send request to the serverless channel.
+
+```bash
+cd ./build/junction
+./client "Your Message"
+```
+
+You should see the server response if it was successful.

--- a/junction/samples/serverless/README.md
+++ b/junction/samples/serverless/README.md
@@ -23,7 +23,7 @@ Open a new terminal and send request to the serverless channel.
 
 ```bash
 cd ./build/junction
-./samples/serverless/client "Your Message"
+./junction_run ./samples/serverless/caladan_client.config -- ./samples/serverless/client "your request"
 ```
 
 You should see the server response if it was successful.

--- a/junction/samples/serverless/README.md
+++ b/junction/samples/serverless/README.md
@@ -11,7 +11,7 @@ cd ./build/junction
 ./junction_run ./samples/serverless/caladan_function.config --function_name sample --function_arg warmup_data -- ./samples/serverless/function
 ```
 
-After the warmup completes, run in restored mode.
+After the warmup completes, run in restored mode to continue from the main function.
 
 ```bash
 ./junction_run ./samples/serverless/caladan_function.config --restore --function_name sample --function_arg restore -- .metadata .elf

--- a/junction/samples/serverless/README.md
+++ b/junction/samples/serverless/README.md
@@ -5,5 +5,6 @@
 ### Function
 
 ```bash
-./build/junction/junction_run ./build/junction/samples/serverless/caladan_function.config --function_arg warmup_data --keep_alive -- ./build/junction/samples/serverless/function
+cd ./build/junction
+./junction_run ./samples/serverless/caladan_function.config --function_arg warmup_data --keep_alive -- ./samples/serverless/function
 ```

--- a/junction/samples/serverless/README.md
+++ b/junction/samples/serverless/README.md
@@ -4,11 +4,17 @@
 
 ### Function
 
-This will start the serverless function.
+This will warmup the serverless function.
 
 ```bash
 cd ./build/junction
-./junction_run ./samples/serverless/caladan_function.config --function_arg warmup_data --keep_alive -- ./samples/serverless/function
+./junction_run ./samples/serverless/caladan_function.config --function_name sample --function_arg warmup_data -- ./samples/serverless/function
+```
+
+After the warmup completes, run in restored mode.
+
+```bash
+./junction_run ./samples/serverless/caladan_function.config --restore --function_name sample --function_arg restore -- .metadata .elf
 ```
 
 ### Client

--- a/junction/samples/serverless/README.md
+++ b/junction/samples/serverless/README.md
@@ -23,7 +23,9 @@ Open a new terminal and send request to the serverless channel.
 
 ```bash
 cd ./build/junction
-./junction_run ./samples/serverless/caladan_client.config -- ./samples/serverless/client "your request"
+./junction_run ./samples/serverless/caladan_client.config -- ./samples/serverless/client "GET /user/0"
 ```
+
+The server is able to get or add users. The valid requests are "GET /user/{id}" and "POST /user {name}".
 
 You should see the server response if it was successful.

--- a/junction/samples/serverless/README.md
+++ b/junction/samples/serverless/README.md
@@ -17,7 +17,7 @@ Open a new terminal and send request to the serverless channel.
 
 ```bash
 cd ./build/junction
-./client "Your Message"
+./samples/serverless/client "Your Message"
 ```
 
 You should see the server response if it was successful.

--- a/junction/samples/serverless/client.cc
+++ b/junction/samples/serverless/client.cc
@@ -3,7 +3,9 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <cstdint>
 #include <iostream>
+#include <vector>
 
 constexpr int PORT = 43;
 constexpr const char* HOST = "192.168.127.7";
@@ -39,11 +41,41 @@ bool ConnectToServer() {
 void CloseConnection() { close(fd); }
 
 bool WriteRequest(const std::string& req) {
+  std::cout << "Sending: " << req << "\n";
   const char* data = req.c_str();
+  uint64_t len = req.length();
+
+  if (write(fd, &len, sizeof(len)) != sizeof(len)) {
+    std::cerr << "Failed to write length header\n";
+    return false;
+  }
+
+  if (write(fd, data, len) != len) {
+    std::cerr << "Failed to write data\n";
+    return false;
+  }
   return true;
 }
 
-bool ReadResponse(std::string& response) { return true; }
+bool ReadResponse(std::string& res) {
+  uint64_t len = 0;
+  if (read(fd, &len, sizeof(len)) != sizeof(len)) {
+    std::cerr << "Failed to read response length\n";
+    return false;
+  }
+
+  if (len == 0) { return true; }
+
+  std::vector<char> buffer(len);
+  if (read(fd, buffer.data(), len) != len) {
+    std::cerr << "Failed to read response data\n";
+    return false;
+  }
+
+  res = std::string(buffer.data(), len);
+  std::cout << "Server Response: " << res << "\n";
+  return true;
+}
 
 }  // namespace
 

--- a/junction/samples/serverless/client.cc
+++ b/junction/samples/serverless/client.cc
@@ -1,0 +1,66 @@
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <iostream>
+
+constexpr int PORT = 43;
+constexpr const char* HOST = "192.168.127.7";
+
+namespace {
+
+int fd = -1;
+
+bool ConnectToServer() {
+  fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) {
+    std::cerr << "Failed to create socket\n";
+    return false;
+  }
+
+  sockaddr_in server_addr;
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_port = htons(PORT);
+  if (inet_pton(AF_INET, HOST, &server_addr.sin_addr) <= 0) {
+    std::cerr << "Failed to set server IP address\n";
+    return false;
+  }
+
+  std::cout << "Connecting to " << HOST << ":" << PORT << "...\n";
+  if (connect(fd, reinterpret_cast<sockaddr*>(&server_addr),
+              sizeof(server_addr)) < 0) {
+    std::cerr << "Failed to connect to server\n";
+    return false;
+  }
+  return true;
+}
+
+void CloseConnection() { close(fd); }
+
+bool WriteRequest(const std::string& req) {
+  const char* data = req.c_str();
+  return true;
+}
+
+bool ReadResponse(std::string& response) { return true; }
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  if (argc < 2) {
+    std::cerr << "Usage: ./client \"Your request string\"\n";
+    return 1;
+  }
+  std::string req = argv[1];
+
+  if (!ConnectToServer()) { return 1; }
+
+  if (!WriteRequest(req)) { return 1; }
+
+  std::string res;
+  if (!ReadResponse(res)) { return 1; }
+
+  CloseConnection();
+  return 0;
+}

--- a/junction/samples/serverless/function.cc
+++ b/junction/samples/serverless/function.cc
@@ -1,6 +1,8 @@
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <string>
+#include <unordered_map>
 
 constexpr const char* CHANNEL_PATH = "/serverless/chan0";
 constexpr const char* SNAPSHOT_REQ = "SNAPSHOT_PREPARE";
@@ -43,18 +45,46 @@ bool Warmup() {
   return true;
 }
 
-bool Function() {
-  std::cout << "Waiting for request..." << std::endl;
+std::unordered_map<int, std::string> users = {
+    {0, "Alice"}, {1, "Bob"}, {2, "Carrol"}, {3, "David"}};
+int count = 4;
+
+void GetUserHandler(int user_id) {
+  try {
+    std::string_view user = users.at(user_id);
+    channel << user;
+  } catch (...) { channel << "User not found"; }
+}
+
+void AddUserHandler(const std::string& name) {
+  users.insert({count, name});
+  channel << "Added {" << count << ": " << name << "}";
+  count++;
+}
+
+bool Router() {
   std::string req_line;
-  while (true) {
-    if (!std::getline(channel, req_line)) {
-      std::cerr << "Failed to read request" << std::endl;
-      return false;
-    }
-    std::cout << "Recieved request: " << req_line << std::endl;
-    std::string res = "Echo: " + req_line;
+  if (!std::getline(channel, req_line)) {
+    std::cerr << "Failed to read request" << std::endl;
+    return false;
+  }
+
+  std::string res;
+  std::stringstream ss(req_line);
+  std::string method;
+  std::string path;
+  std::string name;
+  ss >> method;
+  ss >> path;
+  if (method == "GET" && path.rfind("/user/", 0) == 0) {
+    int user_id = std::stoi(path.substr(6));
+    GetUserHandler(user_id);
+  } else if (method == "POST" && path == "/user") {
+    ss >> name;
+    AddUserHandler(name);
+  } else {
+    res = "Invalid Request: " + req_line;
     channel << res;
-    std::cout << "Processed: " << req_line << std::endl;
   }
   return true;
 }
@@ -71,10 +101,7 @@ int main() {
     return 1;
   }
 
-  if (!Function()) {
-    CloseChannel();
-    return 1;
-  }
+  while (Router()) {}
 
   CloseChannel();
 

--- a/junction/samples/serverless/function.cc
+++ b/junction/samples/serverless/function.cc
@@ -43,12 +43,20 @@ bool Warmup() {
   return true;
 }
 
-void Function() {
+bool Function() {
+  std::cout << "Waiting for request..." << std::endl;
   std::string req_line;
-  while (std::getline(channel, req_line)) {
+  while (true) {
+    if (!std::getline(channel, req_line)) {
+      std::cerr << "Failed to read request" << std::endl;
+      return false;
+    }
+    std::cout << "Recieved request: " << req_line << std::endl;
     std::string res = "Echo: " + req_line;
     channel << res;
+    std::cout << "Processed: " << req_line << std::endl;
   }
+  return true;
 }
 
 void CloseChannel() { channel.close(); }
@@ -58,9 +66,15 @@ void CloseChannel() { channel.close(); }
 int main() {
   if (!OpenChannel()) { return 1; }
 
-  Warmup();
+  if (!Warmup()) {
+    CloseChannel();
+    return 1;
+  }
 
-  Function();
+  if (!Function()) {
+    CloseChannel();
+    return 1;
+  }
 
   CloseChannel();
 

--- a/junction/samples/serverless/function.cc
+++ b/junction/samples/serverless/function.cc
@@ -1,4 +1,3 @@
-#include <array>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -19,7 +18,7 @@ bool OpenChannel() {
     return false;
   }
   std::cout << "Function process started. Waiting for requests on "
-            << CHANNEL_PATH << "\n";
+            << CHANNEL_PATH << std::endl;
   return true;
 }
 

--- a/junction/samples/serverless/function.cc
+++ b/junction/samples/serverless/function.cc
@@ -35,9 +35,9 @@ bool Warmup() {
     if (req_line == SNAPSHOT_REQ) {
       channel << OK;
       std::cout << "Sent snapshot OK response." << std::endl;
-    } else {
-      channel << "Processed: " << req_line;
+      break;
     }
+    channel << "Processed: " << req_line;
   }
   std::cout << "Completed warmup process" << std::endl;
   return true;

--- a/junction/samples/serverless/function.cc
+++ b/junction/samples/serverless/function.cc
@@ -14,7 +14,7 @@ bool OpenChannel() {
   channel.open(CHANNEL_PATH);
 
   if (!channel.is_open()) {
-    std::cerr << "Failed to open serverless channel\n";
+    std::cerr << "Failed to open serverless channel" << std::endl;
     return false;
   }
   std::cout << "Function process started. Waiting for requests on "
@@ -23,23 +23,23 @@ bool OpenChannel() {
 }
 
 bool Warmup() {
-  std::cout << "Handling warmup process\n";
+  std::cout << "Handling warmup process" << std::endl;
   std::string req_line;
   while (true) {
     if (!std::getline(channel, req_line)) {
-      std::cerr << "Failed to read warmup request\n";
+      std::cerr << "Failed to read warmup request" << std::endl;
       return false;
     }
 
-    std::cout << "Recieved request: " << req_line << "\n";
+    std::cout << "Recieved request: " << req_line << std::endl;
     if (req_line == SNAPSHOT_REQ) {
       channel << OK;
-      std::cout << "Sent snapshot OK response.\n";
+      std::cout << "Sent snapshot OK response." << std::endl;
     } else {
-      channel << "Processed: " << req_line << "\n";
+      channel << "Processed: " << req_line;
     }
   }
-  std::cout << "Completed warmup process\n";
+  std::cout << "Completed warmup process" << std::endl;
   return true;
 }
 

--- a/junction/samples/serverless/function.cc
+++ b/junction/samples/serverless/function.cc
@@ -1,15 +1,15 @@
 #include <array>
 #include <fstream>
 #include <iostream>
+#include <string>
 
 constexpr const char* CHANNEL_PATH = "/serverless/chan0";
-constexpr size_t BUF_SIZE = 1024;
-constexpr int WARMUP_COUNT = 10;
+constexpr const char* SNAPSHOT_REQ = "SNAPSHOT_PREPARE";
+constexpr const char* OK = "OK";
 
 namespace {
 
 std::fstream channel;
-std::array<char, BUF_SIZE> read_buf;
 
 bool OpenChannel() {
   channel.open(CHANNEL_PATH);
@@ -25,18 +25,22 @@ bool OpenChannel() {
 
 bool Warmup() {
   std::cout << "Handling warmup process\n";
-  int i = 0;
-  while (i < WARMUP_COUNT) {
-    channel.read(read_buf.data(), read_buf.size());
-    std::streamsize bytes_read = channel.gcount();
-
-    if (bytes_read <= 0) {
+  std::string request_line;
+  while (true) {
+    if (!std::getline(channel, request_line)) {
       std::cerr << "Failed to read warmup request\n";
       return false;
     }
-    std::cout << "Recieved request: " << read_buf.data() << "\n";
-    i++;
+
+    std::cout << "Recieved request: " << request_line << "\n";
+    if (request_line == SNAPSHOT_REQ) {
+      channel << OK << "\n";
+      std::cout << "Sent snapsho OK response.\n";
+    } else {
+      channel << "Processed: " << request_line << "\n";
+    }
   }
+  std::cout << "Completed warmup process\n";
   return true;
 }
 

--- a/junction/samples/serverless/function.cc
+++ b/junction/samples/serverless/function.cc
@@ -1,62 +1,52 @@
+#include <array>
 #include <fstream>
 #include <iostream>
-#include <string>
 
-// The "magic" file that the Junction serverless implementation provides.
-#define CHANNEL_PATH "/serverless/chan0"
+constexpr const char* CHANNEL_PATH = "/serverless/chan0";
+constexpr size_t BUF_SIZE = 1024;
+constexpr int WARMUP_COUNT = 10;
 
-int main() {
-  std::string line;
-  char read_buf[1024];
-  char write_buf[1024];
-  ssize_t bytes_read;
-  int fd;
+namespace {
 
-  // Open the channel for both reading and writing.
-  // This is the C equivalent of the app getting its "port".
-  fd = open(CHANNEL_PATH, O_RDWR);
-  if (fd < 0) {
-    perror("Failed to open serverless channel");
-    return 1;
+std::fstream channel;
+std::array<char, BUF_SIZE> read_buf;
+
+bool OpenChannel() {
+  channel.open(CHANNEL_PATH);
+
+  if (!channel.is_open()) {
+    std::cerr << "Failed to open serverless channel\n";
+    return false;
   }
+  return true;
+}
 
-  printf("Function process started. Waiting for requests on %s\n",
-         CHANNEL_PATH);
-
-  // This is the main serverless loop, processing one request at a time.
-  while (1) {
-    // Clear the read buffer
-    memset(read_buf, 0, sizeof(read_buf));
-
-    // 1. READ REQUEST
-    // This read() call will BLOCK and sleep until the junction
-    // runtime provides a request.
-    printf("Waiting for next request...\n");
-    bytes_read = read(fd, read_buf, sizeof(read_buf) - 1);
+bool Warmup() {
+  int i = 0;
+  while (i < WARMUP_COUNT) {
+    channel.read(read_buf.data(), read_buf.size());
+    std::streamsize bytes_read = channel.gcount();
 
     if (bytes_read <= 0) {
-      // Error or channel closed
-      perror("Error reading from channel");
-      break;
+      std::cerr << "Failed to read warmup request\n";
+      return false;
     }
-
-    // The 'serverless.cc' code adds a newline. We'll strip it.
-    if (read_buf[bytes_read - 1] == '\n') { read_buf[bytes_read - 1] = '\0'; }
-
-    printf("Received request: '%s'\n", read_buf);
-
-    // 2. PROCESS LOGIC
-    // Our "business logic" is to create a greeting string.
-    // snprintf(write_buf, sizeof(write_buf), "Hello, %s!", read_buf);
-    sprintf(write_buf, "OK");
-
-    // 3. WRITE RESPONSE
-    // This write() call sends the response back to the junction
-    // runtime and unblocks the waiting ChannelWorker.
-    printf("Sending response: '%s'\n", write_buf);
-    write(fd, write_buf, strlen(write_buf));
+    std::cout << "Recieved request: " << read_buf.data() << "\n";
+    i++;
   }
+  return true;
+}
 
-  close(fd);
+void CloseChannel() { channel.close(); }
+
+}  // namespace
+
+int main() {
+  if (!OpenChannel()) { return 1; }
+
+  Warmup();
+
+  CloseChannel();
+
   return 0;
 }

--- a/junction/samples/serverless/function.cc
+++ b/junction/samples/serverless/function.cc
@@ -34,8 +34,8 @@ bool Warmup() {
 
     std::cout << "Recieved request: " << request_line << "\n";
     if (request_line == SNAPSHOT_REQ) {
-      channel << OK << "\n";
-      std::cout << "Sent snapsho OK response.\n";
+      channel << OK;
+      std::cout << "Sent snapshot OK response.\n";
     } else {
       channel << "Processed: " << request_line << "\n";
     }

--- a/junction/samples/serverless/function.cc
+++ b/junction/samples/serverless/function.cc
@@ -1,0 +1,62 @@
+#include <fstream>
+#include <iostream>
+#include <string>
+
+// The "magic" file that the Junction serverless implementation provides.
+#define CHANNEL_PATH "/serverless/chan0"
+
+int main() {
+  std::string line;
+  char read_buf[1024];
+  char write_buf[1024];
+  ssize_t bytes_read;
+  int fd;
+
+  // Open the channel for both reading and writing.
+  // This is the C equivalent of the app getting its "port".
+  fd = open(CHANNEL_PATH, O_RDWR);
+  if (fd < 0) {
+    perror("Failed to open serverless channel");
+    return 1;
+  }
+
+  printf("Function process started. Waiting for requests on %s\n",
+         CHANNEL_PATH);
+
+  // This is the main serverless loop, processing one request at a time.
+  while (1) {
+    // Clear the read buffer
+    memset(read_buf, 0, sizeof(read_buf));
+
+    // 1. READ REQUEST
+    // This read() call will BLOCK and sleep until the junction
+    // runtime provides a request.
+    printf("Waiting for next request...\n");
+    bytes_read = read(fd, read_buf, sizeof(read_buf) - 1);
+
+    if (bytes_read <= 0) {
+      // Error or channel closed
+      perror("Error reading from channel");
+      break;
+    }
+
+    // The 'serverless.cc' code adds a newline. We'll strip it.
+    if (read_buf[bytes_read - 1] == '\n') { read_buf[bytes_read - 1] = '\0'; }
+
+    printf("Received request: '%s'\n", read_buf);
+
+    // 2. PROCESS LOGIC
+    // Our "business logic" is to create a greeting string.
+    // snprintf(write_buf, sizeof(write_buf), "Hello, %s!", read_buf);
+    sprintf(write_buf, "OK");
+
+    // 3. WRITE RESPONSE
+    // This write() call sends the response back to the junction
+    // runtime and unblocks the waiting ChannelWorker.
+    printf("Sending response: '%s'\n", write_buf);
+    write(fd, write_buf, strlen(write_buf));
+  }
+
+  close(fd);
+  return 0;
+}

--- a/junction/samples/serverless/function.cc
+++ b/junction/samples/serverless/function.cc
@@ -25,23 +25,31 @@ bool OpenChannel() {
 
 bool Warmup() {
   std::cout << "Handling warmup process\n";
-  std::string request_line;
+  std::string req_line;
   while (true) {
-    if (!std::getline(channel, request_line)) {
+    if (!std::getline(channel, req_line)) {
       std::cerr << "Failed to read warmup request\n";
       return false;
     }
 
-    std::cout << "Recieved request: " << request_line << "\n";
-    if (request_line == SNAPSHOT_REQ) {
+    std::cout << "Recieved request: " << req_line << "\n";
+    if (req_line == SNAPSHOT_REQ) {
       channel << OK;
       std::cout << "Sent snapshot OK response.\n";
     } else {
-      channel << "Processed: " << request_line << "\n";
+      channel << "Processed: " << req_line << "\n";
     }
   }
   std::cout << "Completed warmup process\n";
   return true;
+}
+
+void Function() {
+  std::string req_line;
+  while (std::getline(channel, req_line)) {
+    std::string res = "Echo: " + req_line;
+    channel << res;
+  }
 }
 
 void CloseChannel() { channel.close(); }
@@ -52,6 +60,8 @@ int main() {
   if (!OpenChannel()) { return 1; }
 
   Warmup();
+
+  Function();
 
   CloseChannel();
 

--- a/junction/samples/serverless/function.cc
+++ b/junction/samples/serverless/function.cc
@@ -18,10 +18,13 @@ bool OpenChannel() {
     std::cerr << "Failed to open serverless channel\n";
     return false;
   }
+  std::cout << "Function process started. Waiting for requests on "
+            << CHANNEL_PATH << "\n";
   return true;
 }
 
 bool Warmup() {
+  std::cout << "Handling warmup process\n";
   int i = 0;
   while (i < WARMUP_COUNT) {
     channel.read(read_buf.data(), read_buf.size());


### PR DESCRIPTION
Added a sample serverless program in `junction/samples/serverless`. It includes a function service that handles simple requests, and a client program that can send requests. 
This implementation utilizes the `serverless.cc` implementation of junction.