### PR TITLE
chore: update readme for serverless sample

### DIFF
--- a/junction/samples/serverless/README.md
+++ b/junction/samples/serverless/README.md
@@ -1,20 +1,22 @@
 # Serverless
 
+A simple implementation of a mock FaaS.
+
 ## Junction
 
 ### Function
 
-This will warmup the serverless function.
+This will warmup the function.
 
 ```bash
 cd ./build/junction
-./junction_run ./samples/serverless/caladan_function.config --function_name sample --function_arg warmup_data -- ./samples/serverless/function
+./junction_run ./samples/serverless/caladan_function.config --function_name function_warmup --function_arg warmup_data -- ./samples/serverless/function
 ```
 
-After the warmup completes, run in restored mode to continue from the main function.
+After the warmup completes, run in restored mode to continue from the main function. We will set the `keep_alive` flag to keep the channel alive to listen for client requests.
 
 ```bash
-./junction_run ./samples/serverless/caladan_function.config --restore --function_name sample --function_arg restore -- .metadata .elf
+./junction_run ./samples/serverless/caladan_function.config --restore --function_name function --function_arg restore --keep_alive -- .metadata .elf
 ```
 
 ### Client
@@ -26,6 +28,5 @@ cd ./build/junction
 ./junction_run ./samples/serverless/caladan_client.config -- ./samples/serverless/client "GET /user/0"
 ```
 
-The server is able to get or add users. The valid requests are "GET /user/{id}" and "POST /user {name}".
-
+The server is able to get or add users. The valid requests are "GET /user/{id}" and "POST /user {name}".  
 You should see the server response if it was successful.

--- a/junction/samples/serverless/README.md
+++ b/junction/samples/serverless/README.md
@@ -4,6 +4,10 @@ A simple implementation of a mock FaaS.
 
 ## Junction
 
+### Prepare
+
+Make sure you have built junction using `scripts/build.sh` and the scheduler is running.
+
 ### Function
 
 This will warmup the function.


### PR DESCRIPTION
Updated readme to make instructions clear.
Added `keep_alive` flag when running the function to allow the client program to send requests.