### PR TITLE
chore: merge upstream changes (junction/dev) to dev branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,14 +74,6 @@ jobs:
             lib/.caladan_installed_ver
           key: ${{ runner.os }}-build-${{ env.caladan_commit }}-caladan-${{ hashFiles('lib/patches/caladan/*') }}
 
-      - uses: actions/cache@v4
-        name: Retrieve cached python venv
-        with:
-          path: |
-            bin/venv
-            bin/node_modules
-          key: ${{ runner.os }}-build-venv-${{ hashFiles('scripts/install_function_bench.sh') }}
-
       - name: Install
         run: |
           sudo apt-get update
@@ -96,6 +88,18 @@ jobs:
 
       - name: Main tests
         run: ./scripts/test.sh
+
+      - uses: actions/cache@v4
+        name: Retrieve cached python venv
+        with:
+          path: |
+            bin/venv
+            bin/node_modules
+          key: ${{ runner.os }}-build-venv-${{ hashFiles('scripts/install_function_bench.sh') }}
+
+      - name: Install python venv
+        run: |
+          ./scripts/install_function_bench.sh
 
       - name: Build snapshot tests
         run: |
@@ -167,14 +171,6 @@ jobs:
             lib/.caladan_installed_ver
           key: ${{ runner.os }}-build-${{ env.caladan_commit }}-caladan-${{ hashFiles('lib/patches/caladan/*') }}
 
-      - uses: actions/cache@v4
-        name: Retrieve cached python venv
-        with:
-          path: |
-            bin/venv
-            bin/node_modules
-          key: ${{ runner.os }}-build-venv-${{ hashFiles('scripts/install_function_bench.sh') }}
-
       - name: Install
         run: |
           sudo apt-get update
@@ -189,6 +185,18 @@ jobs:
 
       - name: Main tests (debug)
         run: ./scripts/test.sh -d
+
+      - uses: actions/cache@v4
+        name: Retrieve cached python venv
+        with:
+          path: |
+            bin/venv
+            bin/node_modules
+          key: ${{ runner.os }}-build-venv-${{ hashFiles('scripts/install_function_bench.sh') }}
+
+      - name: Install python venv
+        run: |
+          ./scripts/install_function_bench.sh
 
       - name: Build snapshot tests (debug)
         run: |
@@ -269,13 +277,6 @@ jobs:
             bin/node_modules
           key: ${{ runner.os }}-build-venv-${{ hashFiles('scripts/install_function_bench.sh') }}
 
-      - uses: actions/cache@v4
-        name: Retrieve cached chroot environment
-        with:
-          path: |
-            chroot.tar.gz
-          key: ${{ runner.os }}-build-venv-${{ hashFiles('scripts/install_chroot.sh') }}
-
       - name: Install
         run: |
           sudo apt-get update
@@ -294,6 +295,18 @@ jobs:
 
       - name: Main tests
         run: ./scripts/test.sh --use-chroot
+
+      - uses: actions/cache@v4
+        name: Retrieve cached python venv
+        with:
+          path: |
+            bin/venv
+            bin/node_modules
+          key: ${{ runner.os }}-build-venv-${{ hashFiles('scripts/install_function_bench.sh') }}
+
+      - name: Install python venv
+        run: |
+          ./scripts/install_function_bench.sh
 
       - name: Build snapshot tests
         run: |
@@ -366,14 +379,6 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.caladan_commit }}-caladan-${{ hashFiles('lib/patches/caladan/*') }}
 
       - uses: actions/cache@v4
-        name: Retrieve cached python venv
-        with:
-          path: |
-            bin/venv
-            bin/node_modules
-          key: ${{ runner.os }}-build-venv-${{ hashFiles('scripts/install_function_bench.sh') }}
-
-      - uses: actions/cache@v4
         name: Retrieve cached chroot environment
         with:
           path: |
@@ -398,6 +403,18 @@ jobs:
 
       - name: Main tests (debug)
         run: ./scripts/test.sh -d --use-chroot
+
+      - uses: actions/cache@v4
+        name: Retrieve cached python venv
+        with:
+          path: |
+            bin/venv
+            bin/node_modules
+          key: ${{ runner.os }}-build-venv-${{ hashFiles('scripts/install_function_bench.sh') }}
+
+      - name: Install python venv
+        run: |
+          ./scripts/install_function_bench.sh
 
       - name: Build snapshot tests (debug)
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ lib/.caladan_installed_ver
 lib/.glibc_installed_ver
 lib/.jiftools_installed_ver
 .install_script_ran
+.function_bench_installed
 *.snapshot
 *.elf
 *.metadata

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ results/**
 lib/.caladan_installed_ver
 lib/.glibc_installed_ver
 lib/.jiftools_installed_ver
+.install_script_ran
 *.snapshot
 *.elf
 *.metadata

--- a/junction-ctl/Cargo.toml
+++ b/junction-ctl/Cargo.toml
@@ -9,5 +9,6 @@ edition = "2021"
 anyhow = "1.0.81"
 clap = { version = "4.5.4", features = ["derive"] }
 easy-repl = "0.2.1"
+libc = "0.2"
 
 flatbuffers = { path = "../lib/flatbuffers/rust/flatbuffers" }

--- a/junction-ctl/src/main.rs
+++ b/junction-ctl/src/main.rs
@@ -5,12 +5,13 @@ use flatbuffers::FlatBufferBuilder;
 
 use std::io::{Read, Write};
 use std::net::TcpStream;
+use std::time::Duration;
 
 use crate::control_request_generated::junction::ctl_schema::{
     finish_size_prefixed_request_buffer, GetStatsRequest, GetStatsRequestArgs, InnerRequest,
-    Request, RequestArgs, RestoreRequest, RestoreRequestArgs, RunRequest, RunRequestArgs,
-    SignalRequest, SignalRequestArgs, SnapshotRequest, SnapshotRequestArgs, StartTraceRequest,
-    StartTraceRequestArgs, StopTraceRequest, StopTraceRequestArgs,
+    PSRequest, PSRequestArgs, Request, RequestArgs, RestoreRequest, RestoreRequestArgs, RunRequest,
+    RunRequestArgs, SignalRequest, SignalRequestArgs, SnapshotRequest, SnapshotRequestArgs,
+    StartTraceRequest, StartTraceRequestArgs, StopTraceRequest, StopTraceRequestArgs,
 };
 
 use self::control_response_generated::junction::ctl_schema::{
@@ -43,6 +44,8 @@ enum GoodResponse {
     Stats,
     Trace(TraceReport),
     InvocationResult(String),
+    RunResult(i32),
+    PSResult(Vec<i32>),
 }
 
 fn parse_signal(s: &str) -> Result<u64, String> {
@@ -110,6 +113,8 @@ enum Command {
     },
     RunAux {
         bin: String,
+        cwd: String,
+        fsroot: String,
         argv: Vec<String>,
     },
     Snapshot {
@@ -135,9 +140,10 @@ enum Command {
         signal: u64,
     },
     GetStats,
+    PS,
 }
 
-fn await_response(mut stream: TcpStream) -> anyhow::Result<GoodResponse> {
+fn await_response(mut stream: &TcpStream) -> anyhow::Result<GoodResponse> {
     let mut size_buf = [0; std::mem::size_of::<u32>()];
     stream
         .read_exact(&mut size_buf)
@@ -198,6 +204,21 @@ fn await_response(mut stream: TcpStream) -> anyhow::Result<GoodResponse> {
                 .unwrap_or("<error message not found>");
             Ok(GoodResponse::InvocationResult(result.to_string()))
         }
+        InnerResponse::runResponse => {
+            let pid = resp
+                .inner_as_run_response()
+                .expect("we checked already")
+                .pid();
+            Ok(GoodResponse::RunResult(pid))
+        }
+        InnerResponse::psResponse => {
+            let pids = resp
+                .inner_as_ps_response()
+                .expect("we checked already")
+                .pids()
+                .expect("we checked already");
+            Ok(GoodResponse::PSResult(pids.iter().collect()))
+        }
         InnerResponse::NONE | _ => Err(anyhow::anyhow!("invalid response")),
     }
 }
@@ -225,7 +246,7 @@ fn cli(uri: &str) -> anyhow::Result<()> {
                         return Err(anyhow::anyhow!("Missing arguments: bin and argv"));
                     }
                     // Call run_aux with the arguments
-                    run_aux(uri, argv[0], &argv[1..])?;
+                    run_aux(uri, argv[0], &argv[1..], "/", "/")?;
                     Ok(CommandStatus::Done)
                 }),
             }
@@ -297,6 +318,16 @@ fn cli(uri: &str) -> anyhow::Result<()> {
                 }
             },
         )
+        .add(
+            "ps",
+            command! {
+                "get all processes",
+                () => || {
+                    ps(uri)?;
+                    Ok(CommandStatus::Done)
+                }
+            },
+        )
         .build()
         .context("Failed to create repl")?;
 
@@ -312,7 +343,7 @@ fn run(uri: &str, argv: &[&str]) -> anyhow::Result<()> {
         .collect::<Vec<_>>();
 
     let bin = Some(fbb.create_string(argv[0]));
-
+    let cwd = Some(fbb.create_string("/"));
     let argv = Some(fbb.create_vector_from_iter(argv_fb.into_iter()));
 
     let run_req = RunRequest::create(
@@ -320,7 +351,10 @@ fn run(uri: &str, argv: &[&str]) -> anyhow::Result<()> {
         &RunRequestArgs {
             bin,
             argv,
+            envp: None,
             is_init: true,
+            cwd: cwd,
+            fsroot: cwd,
         },
     );
 
@@ -339,7 +373,7 @@ fn run(uri: &str, argv: &[&str]) -> anyhow::Result<()> {
         .write_all(fbb.finished_data())
         .context("failed to write run request")?;
 
-    match await_response(stream)? {
+    match await_response(&stream)? {
         GoodResponse::Ok => Ok(()),
         _ => Err(anyhow::anyhow!(
             "mismatched response (expected SuccessResponse)"
@@ -347,10 +381,12 @@ fn run(uri: &str, argv: &[&str]) -> anyhow::Result<()> {
     }
 }
 
-fn run_aux(uri: &str, bin: &str, argv: &[&str]) -> anyhow::Result<()> {
+fn run_aux(uri: &str, bin: &str, argv: &[&str], cwd: &str, fsroot: &str) -> anyhow::Result<()> {
     let mut fbb = FlatBufferBuilder::new();
 
     let bin = Some(fbb.create_string(bin));
+    let cwd = Some(fbb.create_string(cwd));
+    let fsroot = Some(fbb.create_string(fsroot));
     let argv_fb = argv
         .iter()
         .map(|s| fbb.create_string(s))
@@ -362,7 +398,10 @@ fn run_aux(uri: &str, bin: &str, argv: &[&str]) -> anyhow::Result<()> {
         &RunRequestArgs {
             bin,
             argv,
+            envp:None,
             is_init: false,
+            cwd: cwd,
+            fsroot: fsroot,
         },
     );
 
@@ -381,12 +420,33 @@ fn run_aux(uri: &str, bin: &str, argv: &[&str]) -> anyhow::Result<()> {
         .write_all(fbb.finished_data())
         .context("failed to write run request")?;
 
-    match await_response(stream)? {
+    match await_response(&stream)? {
         GoodResponse::Ok => Ok(()),
+        GoodResponse::RunResult(p) => {
+            eprintln!("started pid {}", p);
+            Ok(())
+        }
         _ => Err(anyhow::anyhow!(
             "mismatched response (expected SuccessResponse)"
         )),
     }
+    .unwrap();
+
+    // Read bytes from stream and print to stdout until stream is closed:
+    let mut buffer = [0; 1024];
+    loop {
+        let n = stream
+            .read(&mut buffer)
+            .context("failed to read from stream")?;
+        if n == 0 {
+            break;
+        }
+        // Write read bytes directly to stdout
+        std::io::stdout()
+            .write_all(&buffer[..n])
+            .context("failed to write to stdout")?;
+    }
+    Ok(())
 }
 
 fn snapshot(uri: &str, pid: u64, snapshot_path: &str, elf_path: &str) -> anyhow::Result<()> {
@@ -416,7 +476,7 @@ fn snapshot(uri: &str, pid: u64, snapshot_path: &str, elf_path: &str) -> anyhow:
         .write_all(fbb.finished_data())
         .context("failed to write snapshot request")?;
 
-    match await_response(stream)? {
+    match await_response(&stream)? {
         GoodResponse::Ok => Ok(()),
         _ => Err(anyhow::anyhow!(
             "mismatched response (expected SuccessResponse)"
@@ -453,7 +513,7 @@ fn restore(uri: &str, snapshot_path: &str, elf_path: &str, args: &str) -> anyhow
         .write_all(fbb.finished_data())
         .context("failed to write snapshot request")?;
 
-    match await_response(stream)? {
+    match await_response(&stream)? {
         GoodResponse::Ok => Ok(()),
         GoodResponse::InvocationResult(s) => {
             println!("Got response {}", s);
@@ -483,7 +543,7 @@ fn start_trace(uri: &str, pid: u64) -> anyhow::Result<()> {
         .write_all(fbb.finished_data())
         .context("failed to write snapshot request")?;
 
-    match await_response(stream)? {
+    match await_response(&stream)? {
         GoodResponse::Ok => Ok(()),
         _ => Err(anyhow::anyhow!(
             "mismatched response (expected SuccessResponse)"
@@ -508,7 +568,7 @@ fn stop_trace(uri: &str, pid: u64) -> anyhow::Result<()> {
         .write_all(fbb.finished_data())
         .context("failed to write snapshot request")?;
 
-    match await_response(stream)? {
+    match await_response(&stream)? {
         GoodResponse::Ok => Err(anyhow::anyhow!(
             "mismatched response (expected Trace, got SuccessResponse)"
         )),
@@ -541,13 +601,48 @@ fn signal(uri: &str, pid: u64, signo: u64) -> anyhow::Result<()> {
         .write_all(fbb.finished_data())
         .context("failed to write snapshot request")?;
 
-    match await_response(stream)? {
+    match await_response(&stream)? {
         GoodResponse::Ok => Ok(()),
         _ => Err(anyhow::anyhow!(
             "mismatched response (expected SuccessResponse)"
         )),
     }
 }
+
+fn ps(uri: &str) -> anyhow::Result<()> {
+    let mut fbb = FlatBufferBuilder::new();
+    let inner = PSRequest::create(&mut fbb, &PSRequestArgs {});
+
+    let req = Request::create(
+        &mut fbb,
+        &RequestArgs {
+            inner_type: InnerRequest::ps,
+            inner: Some(inner.as_union_value()),
+        },
+    );
+
+    finish_size_prefixed_request_buffer(&mut fbb, req);
+    let mut stream = get_stream(uri)?;
+    stream
+        .write_all(fbb.finished_data())
+        .context("failed to write ps request")?;
+
+    match await_response(&stream)? {
+        GoodResponse::PSResult(pids) => {
+            print!("[");
+            for (i, pid) in pids.iter().enumerate() {
+                print!("{}", pid);
+                if i < pids.len() - 1 {
+                    print!(", ");
+                }
+            }
+            println!("]");
+            Ok(())
+        }
+        _ => Err(anyhow::anyhow!("mismatched response (expected PSResponse)")),
+    }
+}
+
 fn get_stats(uri: &str) -> anyhow::Result<()> {
     let mut fbb = FlatBufferBuilder::new();
     let inner = GetStatsRequest::create(&mut fbb, &GetStatsRequestArgs {});
@@ -566,7 +661,7 @@ fn get_stats(uri: &str) -> anyhow::Result<()> {
         .write_all(fbb.finished_data())
         .context("failed to write snapshot request")?;
 
-    match await_response(stream)? {
+    match await_response(&stream)? {
         GoodResponse::Stats => Ok(()),
         _ => Err(anyhow::anyhow!(
             "mismatched response (expected GetStatsResponse)"
@@ -575,7 +670,8 @@ fn get_stats(uri: &str) -> anyhow::Result<()> {
 }
 
 fn get_stream(uri: &str) -> anyhow::Result<TcpStream> {
-    TcpStream::connect(uri).context(format!("failed to connect to {}", uri))
+    TcpStream::connect_timeout(&uri.parse().unwrap(), Duration::from_secs(3))
+        .context(format!("failed to connect to {}", uri))
 }
 
 fn main() -> anyhow::Result<()> {
@@ -588,9 +684,20 @@ fn main() -> anyhow::Result<()> {
             let args = argv.iter().map(|x| x.as_str()).collect::<Vec<&str>>();
             run(uri.as_str(), args.as_slice())
         }
-        Some(Command::RunAux { bin, argv }) => {
+        Some(Command::RunAux {
+            bin,
+            cwd,
+            fsroot,
+            argv,
+        }) => {
             let args = argv.iter().map(|x| x.as_str()).collect::<Vec<&str>>();
-            run_aux(uri.as_str(), bin.as_str(), args.as_slice())
+            run_aux(
+                uri.as_str(),
+                bin.as_str(),
+                args.as_slice(),
+                cwd.as_str(),
+                fsroot.as_str(),
+            )
         }
         Some(Command::Snapshot {
             pid,
@@ -611,5 +718,6 @@ fn main() -> anyhow::Result<()> {
         Some(Command::StopTrace { pid }) => stop_trace(uri.as_str(), pid),
         Some(Command::Signal { pid, signal: signo }) => signal(uri.as_str(), pid, signo),
         Some(Command::GetStats) => get_stats(uri.as_str()),
+        Some(Command::PS) => ps(uri.as_str()),
     }
 }

--- a/junction/base/io.h
+++ b/junction/base/io.h
@@ -61,6 +61,16 @@ inline std::span<const std::byte> writable_span(const char *buf, size_t len) {
   return {reinterpret_cast<const std::byte *>(buf), len};
 }
 
+// Cast a legacy UNIX read buffer as a span.
+inline std::span<std::byte> readable_span(void *buf, size_t len) {
+  return {reinterpret_cast<std::byte *>(buf), len};
+}
+
+// Cast a legacy UNIX write buffer as a span.
+inline std::span<const std::byte> writable_span(const void *buf, size_t len) {
+  return {reinterpret_cast<const std::byte *>(buf), len};
+}
+
 // Cast a legacy UNIX write buffer as a span.
 inline std::span<const std::byte> writable_span(iovec iov) {
   return {reinterpret_cast<const std::byte *>(iov.iov_base), iov.iov_len};

--- a/junction/base/time.h
+++ b/junction/base/time.h
@@ -103,6 +103,11 @@ class Duration {
     return Duration(duration_ + other.Microseconds());
   }
 
+  template <class Archive>
+  void serialize(Archive &ar) {
+    ar(duration_);
+  }
+
  private:
   int64_t duration_;
 };

--- a/junction/bindings/log.h
+++ b/junction/bindings/log.h
@@ -29,6 +29,16 @@ class Logger {
   }
   ~Logger();
 
+  // Helper method targetting strace, where some argument printers may provide
+  // deferred formatting of other arguments via optional stringstreams.
+  bool absorb(std::optional<std::stringstream> &in_ss) {
+    if (!in_ss) return false;
+    RuntimeLibcGuard guard_;
+    if (!ss_) ss_.emplace();
+    *ss_ << in_ss->rdbuf();
+    return true;
+  }
+
   template <typename T>
   Logger &operator<<(T const &value) {
     RuntimeLibcGuard guard_;

--- a/junction/bindings/net.h
+++ b/junction/bindings/net.h
@@ -18,6 +18,8 @@ namespace junction::rt {
 
 // UDP Connections.
 class UDPConn {
+  friend class BindToken;
+
  public:
   UDPConn() = default;
   ~UDPConn() {
@@ -141,6 +143,7 @@ class UDPConn {
 // TCP connections.
 class TCPConn : public VectoredReader, public VectoredWriter {
   friend class TCPQueue;
+  friend class BindToken;
 
  public:
   TCPConn() = default;
@@ -292,6 +295,8 @@ class TCPConn : public VectoredReader, public VectoredWriter {
 
 // TCP listener queues.
 class TCPQueue {
+  friend class BindToken;
+
  public:
   TCPQueue() = default;
   ~TCPQueue() {
@@ -348,6 +353,101 @@ class TCPQueue {
   explicit TCPQueue(tcpqueue_t *q) noexcept : q_(q) {}
 
   tcpqueue_t *q_{nullptr};
+};
+
+// Bind token wrapper for managing port reservations.
+class BindToken {
+ public:
+  BindToken() = default;
+  ~BindToken() {
+    if (is_valid()) trans_release_port(token_);
+  }
+
+  // Move support.
+  BindToken(BindToken &&other) noexcept
+      : token_(std::exchange(other.token_, nullptr)) {}
+  BindToken &operator=(BindToken &&other) noexcept {
+    token_ = std::exchange(other.token_, nullptr);
+    return *this;
+  }
+
+  // disable copy.
+  BindToken(const BindToken &) = delete;
+  BindToken &operator=(const BindToken &) = delete;
+
+  // Allocates a bind token for the given local address and protocol.
+  static Status<BindToken> Allocate(netaddr laddr, uint8_t proto,
+                                    bool reuse_port = false) {
+    bind_token_t *token = nullptr;
+    int ret = trans_reserve_port(&laddr, proto, reuse_port, &token);
+    if (ret) return MakeError(-ret);
+    return BindToken(token);
+  }
+
+  // Allocates a TCP bind token.
+  static Status<BindToken> AllocateTCP(netaddr laddr, bool reuse_port = false) {
+    return Allocate(laddr, IPPROTO_TCP, reuse_port);
+  }
+
+  // Allocates a UDP bind token.
+  static Status<BindToken> AllocateUDP(netaddr laddr, bool reuse_port = false) {
+    return Allocate(laddr, IPPROTO_UDP, reuse_port);
+  }
+
+  // Checks if this holds a valid bind token.
+  [[nodiscard]] bool is_valid() const { return token_ != nullptr; }
+
+  // Gets the local address associated with this token.
+  [[nodiscard]] netaddr LocalAddr() const { return get_netaddr(token_); }
+
+  // Consumes this token for a TCP dial operation.
+  Status<TCPConn> DialTCP(netaddr raddr, bool nonblocking = false) {
+    if (!is_valid()) return MakeError(EINVAL);
+    tcpconn_t *c;
+    int ret = __tcp_dial({}, raddr, &c, nonblocking, token_);
+    if (ret && !(nonblocking && ret == -EINPROGRESS)) return MakeError(-ret);
+    // Token is consumed, clear it
+    token_ = nullptr;
+    return TCPConn(c);
+  }
+
+  // Consumes this token for a TCP listen operation.
+  Status<TCPQueue> ListenTCP(int backlog) {
+    if (!is_valid()) return MakeError(EINVAL);
+    tcpqueue_t *q;
+    int ret = __tcp_listen({}, backlog, &q, token_);
+    if (ret) return MakeError(-ret);
+    // Token is consumed, clear it
+    token_ = nullptr;
+    return TCPQueue(q);
+  }
+
+  // Consumes this token for a UDP dial operation.
+  Status<UDPConn> DialUDP(netaddr raddr) {
+    if (!is_valid()) return MakeError(EINVAL);
+    udpconn_t *c;
+    int ret = __udp_dial({}, raddr, &c, token_);
+    if (ret) return MakeError(-ret);
+    // Token is consumed, clear it
+    token_ = nullptr;
+    return UDPConn(c);
+  }
+
+  // Consumes this token for a UDP listen operation.
+  Status<UDPConn> ListenUDP() {
+    if (!is_valid()) return MakeError(EINVAL);
+    udpconn_t *c;
+    int ret = __udp_listen({}, &c, token_);
+    if (ret) return MakeError(-ret);
+    // Token is consumed, clear it
+    token_ = nullptr;
+    return UDPConn(c);
+  }
+
+ private:
+  explicit BindToken(bind_token_t *token) noexcept : token_(token) {}
+
+  bind_token_t *token_{nullptr};
 };
 
 }  // namespace junction::rt

--- a/junction/bindings/net.h
+++ b/junction/bindings/net.h
@@ -87,7 +87,7 @@ class UDPConn {
   Status<size_t> ReadvFrom(std::span<const iovec> iov, netaddr *raddr,
                            bool peek, bool nonblocking) {
     ssize_t ret = udp_readv_from2(c_, iov.data(), static_cast<int>(iov.size()),
-                                  raddr, peek, nonblocking);
+                                  raddr, peek, nonblocking, nullptr);
     if (ret < 0) return MakeError(static_cast<int>(-ret));
     return ret;
   }
@@ -104,7 +104,7 @@ class UDPConn {
   Status<size_t> WritevTo(std::span<const iovec> iov, const netaddr *raddr,
                           bool nonblocking = false) {
     ssize_t ret = udp_writev_to2(c_, iov.data(), static_cast<int>(iov.size()),
-                                 raddr, nonblocking);
+                                 raddr, nonblocking, nullptr);
     if (ret < 0) return MakeError(static_cast<int>(-ret));
     return ret;
   }

--- a/junction/bindings/net.h
+++ b/junction/bindings/net.h
@@ -85,9 +85,10 @@ class UDPConn {
   }
 
   Status<size_t> ReadvFrom(std::span<const iovec> iov, netaddr *raddr,
-                           bool peek, bool nonblocking) {
+                           bool peek, bool nonblocking,
+                           aux_rx_pkt_data *aux = nullptr) {
     ssize_t ret = udp_readv_from2(c_, iov.data(), static_cast<int>(iov.size()),
-                                  raddr, peek, nonblocking, nullptr);
+                                  raddr, peek, nonblocking, aux);
     if (ret < 0) return MakeError(static_cast<int>(-ret));
     return ret;
   }
@@ -102,9 +103,10 @@ class UDPConn {
   }
 
   Status<size_t> WritevTo(std::span<const iovec> iov, const netaddr *raddr,
-                          bool nonblocking = false) {
+                          bool nonblocking = false,
+                          aux_tx_pkt_data *aux = nullptr) {
     ssize_t ret = udp_writev_to2(c_, iov.data(), static_cast<int>(iov.size()),
-                                 raddr, nonblocking, nullptr);
+                                 raddr, nonblocking, aux);
     if (ret < 0) return MakeError(static_cast<int>(-ret));
     return ret;
   }

--- a/junction/bindings/stack.h
+++ b/junction/bindings/stack.h
@@ -107,7 +107,9 @@ __always_inline __nofp void* GetXsaveArea(struct stack& stack) {
 __always_inline __nofp uint64_t
 GetSyscallStackBottom(const struct stack& stack) {
   const uint64_t* rsp = &stack.usable[STACK_PTR_SIZE - XSAVE_AREA_PTR_SIZE - 1];
-  return reinterpret_cast<uint64_t>(rsp);
+  // Stackswitch entry may be in the process of setting up its trapframe on the
+  // syscall stack, subtract the redzone to avoid overwriting it.
+  return reinterpret_cast<uint64_t>(rsp) - kRedzoneSize;
 }
 
 // returns the bottom of a thread's syscall stack

--- a/junction/bindings/timer.h
+++ b/junction/bindings/timer.h
@@ -171,4 +171,19 @@ class WakeOnTimeout {
   Timer<std::function<void()>> timer_;
 };
 
+// RAII-style object that sets a thread's blocking timer for the caladan
+// runtime.
+class RuntimeWaitqTimeout {
+ public:
+  [[nodiscard]] RuntimeWaitqTimeout(Duration timeout) {
+    thread_self()->waitq_micros = timeout.Microseconds();
+  }
+  ~RuntimeWaitqTimeout() { thread_self()->waitq_micros = 0; }
+  // disable copy and move.
+  RuntimeWaitqTimeout(const RuntimeWaitqTimeout &) = delete;
+  RuntimeWaitqTimeout &operator=(const RuntimeWaitqTimeout &) = delete;
+  RuntimeWaitqTimeout(RuntimeWaitqTimeout &&) = delete;
+  RuntimeWaitqTimeout &operator=(RuntimeWaitqTimeout &&) = delete;
+};
+
 }  // namespace junction::rt

--- a/junction/control/CMakeLists.txt
+++ b/junction/control/CMakeLists.txt
@@ -11,6 +11,7 @@ set(FLATBUFFER_SCHEMA_FILES
 )
 set(FLATBUFFER_GENERATED_CPP_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(FLATBUFFER_GENERATED_RS_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../junction-ctl/src")
+set(FLATBUFFER_GENERATED_PY_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 function(compile_flatbuffers flatbuffers_schemas
                            custom_target_name
@@ -76,14 +77,21 @@ compile_flatbuffers("${FLATBUFFER_SCHEMA_FILES}"
     rs
 )
 
+compile_flatbuffers("${FLATBUFFER_SCHEMA_FILES}"
+    control_schema_py
+    "--python"
+    "${FLATBUFFER_GENERATED_PY_INCLUDE_DIR}"
+    py
+)
+
 add_library(control_fbs INTERFACE)
 target_include_directories(control_fbs INTERFACE
     ${FLATBUFFERS_INCLUDE_DIR}
     )
-add_dependencies(control_fbs control_schema_cpp control_schema_rs)
+add_dependencies(control_fbs control_schema_cpp control_schema_rs control_schema_py)
 
 add_library(control_c_cpp OBJECT ${SOURCES_C_CPP})
-add_dependencies(control_c_cpp control_schema_cpp control_schema_rs)
+add_dependencies(control_c_cpp control_schema_cpp control_schema_rs control_schema_py)
 
 add_library(control STATIC
   $<TARGET_OBJECTS:control_c_cpp>

--- a/junction/control/control_request.fbs
+++ b/junction/control/control_request.fbs
@@ -3,7 +3,10 @@ namespace junction.ctl_schema;
 table RunRequest {
     bin: string;
     argv: [string];
+    envp: [string];
     is_init: bool;
+    cwd: string;
+    fsroot: string;
 }
 
 table SnapshotRequest {
@@ -18,6 +21,8 @@ table RestoreRequest {
     chan: int32;
     argument: string;
 }
+
+table PSRequest {}
 
 table StartTraceRequest {
     pid: uint64;
@@ -39,6 +44,7 @@ table GetStatsRequest {
 union InnerRequest {
     run: RunRequest,
     snapshot: SnapshotRequest,
+    ps: PSRequest,
     restore: RestoreRequest,
     startTrace: StartTraceRequest,
     stopTrace: StopTraceRequest,

--- a/junction/control/control_response.fbs
+++ b/junction/control/control_response.fbs
@@ -14,6 +14,14 @@ table InvokeResponse {
     message: string;
 }
 
+table RunResponse {
+    pid: int;
+}
+
+table PSResponse {
+    pids: [int];
+}
+
 table TracePoint {
     timestamp_us: uint64;
     accessed_location: uint64;
@@ -28,7 +36,9 @@ union InnerResponse {
     genericSuccess: SuccessResponse,
     getStats: GetStatsResponse,
     traceReport: TraceReport,
-    invokeResponse: InvokeResponse
+    invokeResponse: InvokeResponse,
+    runResponse: RunResponse,
+    psResponse: PSResponse,
 }
 
 table Response {

--- a/junction/control/ctl_conn.h
+++ b/junction/control/ctl_conn.h
@@ -63,6 +63,24 @@ class ControlConn {
     return Send(std::move(fbb));
   }
 
+  Status<void> RunResponse(pid_t pid) {
+    flatbuffers::FlatBufferBuilder fbb;
+    auto inner = ctl_schema::CreateRunResponse(fbb, pid);
+    auto resp = ctl_schema::CreateResponse(
+        fbb, ctl_schema::InnerResponse_runResponse, inner.Union());
+    fbb.FinishSizePrefixed(resp);
+    return Send(std::move(fbb));
+  }
+
+  Status<void> PSResponse(const std::vector<pid_t> &pids) {
+    flatbuffers::FlatBufferBuilder fbb;
+    auto inner = ctl_schema::CreatePSResponseDirect(fbb, &pids);
+    auto resp = ctl_schema::CreateResponse(
+        fbb, ctl_schema::InnerResponse_psResponse, inner.Union());
+    fbb.FinishSizePrefixed(resp);
+    return Send(std::move(fbb));
+  }
+
   Status<void> InvokeResponse(const std::string &result) {
     flatbuffers::FlatBufferBuilder fbb;
     auto msg = fbb.CreateString(result);
@@ -106,6 +124,8 @@ class ControlConn {
     fbb.FinishSizePrefixed(resp);
     return Send(std::move(fbb));
   }
+
+  rt::TCPConn &&SeizeConn() { return std::move(conn_); }
 
  private:
   void Reset() { request_ = nullptr; }

--- a/junction/control/webctl.cc
+++ b/junction/control/webctl.cc
@@ -7,9 +7,9 @@
 #include "junction/control/ctl_conn.h"
 #include "junction/control/serverless.h"
 #include "junction/kernel/proc.h"
+#include "junction/net/tcp_socket.h"
 #include "junction/run.h"
 #include "junction/snapshot/snapshot.h"
-
 namespace junction {
 
 bool HandleRun(ControlConn &c, const ctl_schema::RunRequest *req) {
@@ -31,22 +31,26 @@ bool HandleRun(ControlConn &c, const ctl_schema::RunRequest *req) {
   std::vector<std::string_view> argv;
   argv.reserve(argc);
 
-  for (size_t idx = 0; idx < argc; idx += 1) {
+  for (size_t idx = 0; idx < argc; idx += 1)
     argv.push_back(fb_argv->Get(idx)->string_view());
-  }
 
   // Initialize environment and arguments
   auto [envp_s, envp_view] = BuildEnvp();
-  auto proc = CreateFirstProcess(req->bin()->string_view(), argv, envp_view,
-                                 req->is_init());
+
+  for (size_t i = 0; i < req->envp()->size(); i += 1)
+    envp_view.push_back(req->envp()->Get(i)->string_view());
+
+  Thread *th = nullptr;
+  auto proc =
+      CreateFirstProcess(req->bin()->string_view(), argv, envp_view,
+                         req->is_init(), std::string{req->cwd()->string_view()},
+                         std::string{req->fsroot()->string_view()}, &th);
   if (!proc) {
     std::ostringstream error_msg;
     error_msg << "failed to run(";
 
     size_t idx = 0;
-    for (; idx < argc - 1; idx++) {
-      error_msg << argv[idx] << ", ";
-    }
+    for (; idx < argc - 1; idx++) error_msg << argv[idx] << ", ";
     error_msg << argv[idx] << "): " << proc.error();
     if (!c.SendError(error_msg.str())) {
       LOG(WARN) << "ctl: failed to send error: " << error_msg.str();
@@ -55,12 +59,16 @@ bool HandleRun(ControlConn &c, const ctl_schema::RunRequest *req) {
     return false;
   }
 
-  if (!c.SendSuccess()) {
-    LOG(WARN) << "ctl: failed to send success";
+  if (!c.RunResponse((*proc)->get_pid())) {
+    LOG(WARN) << "ctl: failed to send response";
     return true;
   }
 
-  return false;
+  auto file = std::make_shared<TCPSocket>(c.SeizeConn());
+  (*proc)->get_file_table().InsertAt(1, file);
+  (*proc)->get_file_table().InsertAt(2, file);
+  th->ThreadReady();
+  return true;
 }
 bool HandleSnapshot(ControlConn &c, const ctl_schema::SnapshotRequest *req) {
   LOG(INFO) << "handling snapshot request";
@@ -236,6 +244,18 @@ bool HandleGetStats(ControlConn &c, const ctl_schema::GetStatsRequest *req) {
   return false;
 }
 
+bool HandlePS(ControlConn &c, const ctl_schema::PSRequest *req) {
+  LOG(INFO) << "handling ps request";
+  std::vector<pid_t> pids;
+  Process::ForEachProcess(
+      [&pids](const Process &proc) { pids.push_back(proc.get_pid()); });
+
+  if (!c.PSResponse(pids)) {
+    LOG(WARN) << "ctl: failed to send ps response";
+    return true;
+  }
+  return false;
+}
 bool HandleRequest(ControlConn &c, const ctl_schema::Request *req) {
   switch (req->inner_type()) {
     case ctl_schema::InnerRequest_run:
@@ -252,6 +272,8 @@ bool HandleRequest(ControlConn &c, const ctl_schema::Request *req) {
       return HandleSignal(c, req->inner_as_signal());
     case ctl_schema::InnerRequest_getStats:
       return HandleGetStats(c, req->inner_as_getStats());
+    case ctl_schema::InnerRequest_ps:
+      return HandlePS(c, req->inner_as_ps());
     default:
       // TODO(control): send error back
       return true;

--- a/junction/fs/advisory_lock.cc
+++ b/junction/fs/advisory_lock.cc
@@ -4,10 +4,9 @@
 
 namespace junction {
 
-AdvisoryLockMap &AdvisoryLockMap::Get() {
-  static AdvisoryLockMap adv_map;
-  return adv_map;
-}
+static AdvisoryLockMap adv_map;
+
+AdvisoryLockMap &AdvisoryLockMap::Get() { return adv_map; }
 
 AdvisoryLockContext &AdvisoryLockMap::GetCtx(Inode *ino) {
   rt::SpinGuard g(lock_);

--- a/junction/fs/core.cc
+++ b/junction/fs/core.cc
@@ -45,6 +45,7 @@ Status<std::shared_ptr<DirectoryEntry>> WalkPath(
   for (const std::string_view &v : path) {
     if (v.empty() || v == ".") continue;
     if (v == "..") {
+      if (curent == fs.get_root_ent()) continue;
       curent = curent->get_parent_ent();
       curdir = static_cast<IDir *>(&curent->get_inode_ref());
       continue;
@@ -158,6 +159,7 @@ Status<Entry> LookupEntry(const FSRoot &fs, std::shared_ptr<IDir> pos,
   IDir &dir = static_cast<IDir &>(ino);
 
   if (name == "..") {
+    if (*ret == fs.get_root_ent()) return Entry{dir.get_this(), {}, true};
     Status<std::shared_ptr<IDir>> parent = (*ret)->get_parent_dir();
     if (unlikely(!parent)) return MakeError(parent);
     return Entry{std::move(*parent), {}, true};
@@ -293,7 +295,8 @@ Status<std::shared_ptr<File>> ISoftLink::Open(
 // Attempts to get the full path from the root of the filesystem to this IDir by
 // traversing the chain of parents. The result is placed in @dst and an updated
 // span is returned.
-[[nodiscard]] Status<void> DirectoryEntry::GetFullPath(std::ostream &os) {
+[[nodiscard]] Status<void> DirectoryEntry::GetFullPath(const FSRoot &fs,
+                                                       std::ostream &os) {
   // This entry is no longer valid, return the name stored in name_.
   if (!intrusive_ref_) {
     rt::SpinGuard g(lock_);
@@ -307,7 +310,7 @@ Status<std::shared_ptr<File>> ISoftLink::Open(
     auto [name, parent] = cur->get_info();
     if (unlikely(!parent)) return MakeError(ESTALE);
     // TODO - check if the parent is the root instead?
-    if (parent.get() == cur.get()) break;
+    if (cur == fs.get_root_ent()) break;
     paths.emplace_back(std::move(name));
     cur = std::move(parent);
   }
@@ -596,7 +599,7 @@ long usys_getcwd(char *buf, size_t size) {
   FSRoot &fs = myproc().get_fs();
   rt::RuntimeLibcGuard g;
   std::ospanstream out(std::span<char>(buf, size - 1));
-  Status<void> pth = fs.get_cwd_ent()->GetFullPath(out);
+  Status<void> pth = fs.get_cwd_ent()->GetFullPath(fs, out);
   if (unlikely(!pth)) return -ENOENT;
   if (unlikely(out.fail())) return -ERANGE;
   size_t sz = out.span().size();
@@ -803,7 +806,8 @@ void DirectoryEntry::save(cereal::BinaryOutputArchive &ar) const {
     ar(true, name_, get_inode(), get_parent_ent());
   } else {
     std::string path;
-    Status<std::string> ret = const_cast<DirectoryEntry *>(this)->GetPathStr();
+    Status<std::string> ret =
+        const_cast<DirectoryEntry *>(this)->GetPathStr(FSRoot::GetGlobalRoot());
     if (ret) path = std::move(*ret);
     ar(false, path, get_inode());
   }

--- a/junction/fs/core.cc
+++ b/junction/fs/core.cc
@@ -225,8 +225,15 @@ Status<void> HardLink(std::shared_ptr<Inode> src, const Entry &dst_path) {
 Status<std::shared_ptr<File>> Open(const FSRoot &fs, const Entry &path,
                                    int combined_flags, mode_t mode) {
   auto &[idir, name, must_be_dir] = path;
-
   auto [flags, fmode] = FromFlags(combined_flags);
+
+  bool target_must_be_dir = flags & kFlagDirectory;
+  bool target_no_follow = flags & kFlagNoFollow;
+  bool wants_path_file = flags & kFlagPath;
+  bool truncate = flags & kFlagTruncate;
+  bool create = flags & kFlagCreate;
+  bool exclusive = flags & kFlagExclusive;
+  bool wants_temp_file = (flags & kFlagTemp) == kFlagTemp;
 
   // Special case for "/"
   if (!name.size()) {
@@ -236,21 +243,43 @@ Status<std::shared_ptr<File>> Open(const FSRoot &fs, const Entry &path,
 
   Status<std::shared_ptr<DirectoryEntry>> in = idir->LookupDent(name);
   if (!in) {
-    if (flags & kFlagCreate)
+    if (create && !target_must_be_dir)
       return idir->Create(name, flags, mode & ~fs.get_umask(), fmode);
     return MakeError(ENOENT);
   }
 
-  if (flags & kFlagExclusive) return MakeError(EEXIST);
+  if (exclusive && create) return MakeError(EEXIST);
 
-  if ((*in)->get_inode_ref().is_symlink()) {
-    if (!must_be_dir && (flags & (kFlagNoFollow | kFlagPath)) == kFlagNoFollow)
-      return MakeError(ELOOP);
-    in = WalkPath(fs, std::move(idir), {name}, true);
-    if (!in) return MakeError(in);
+  Inode *ino = &(*in)->get_inode_ref();
+  if (target_must_be_dir && !ino->is_dir()) return MakeError(ENOTDIR);
+
+  // Create a temporary file in the directory from @path.
+  if (wants_temp_file) {
+    static_assert(kFlagTemp & kFlagDirectory,
+                  "kFlagTemp implies kFlagDirectory");
+    assert(target_must_be_dir && ino->is_dir());
+    IDir &idir = static_cast<IDir &>(*ino);
+    return idir.CreateTemp(flags, mode & ~fs.get_umask(), fmode);
   }
 
-  if (flags & kFlagTruncate) (*in)->get_inode_ref().SetSize(0);
+  // Resolve symlink unless kFlagNoFollow is set.
+  if (ino->is_symlink()) {
+    if (!target_no_follow) {
+      in = WalkPath(fs, std::move(idir), {name}, true);
+      if (!in) return MakeError(in);
+      ino = &(*in)->get_inode_ref();
+    } else if (!wants_path_file) {
+      return MakeError(ELOOP);
+    }
+  }
+
+  // Caller wants a file that just references this path, does not need
+  // read/write/map operations
+  if (wants_path_file)
+    return std::make_shared<File>(FileType::kPath, flags, fmode,
+                                  std::move(*in));
+
+  if (truncate) ino->SetSize(0);
   return (*in)->Open(flags, fmode);
 }
 

--- a/junction/fs/core.cc
+++ b/junction/fs/core.cc
@@ -379,7 +379,9 @@ long usys_mkdirat(int dirfd, const char *pathname, mode_t mode) {
 }
 
 long usys_unlink(const char *pathname) {
-  Status<Entry> entry = LookupEntry(myproc().get_fs(), pathname);
+  std::string_view pathnamev(pathname);
+  if (pathnamev == "") return -ENOENT;
+  Status<Entry> entry = LookupEntry(myproc().get_fs(), pathnamev);
   if (!entry) return MakeCError(entry);
   Status<void> ret = Unlink(*entry);
   if (!ret) return MakeCError(ret);

--- a/junction/fs/core.cc
+++ b/junction/fs/core.cc
@@ -1,5 +1,9 @@
 // core.cc - core file system support
 
+extern "C" {
+#include <sys/stat.h>
+}
+
 #include <algorithm>
 #include <spanstream>
 #include <utility>
@@ -277,6 +281,12 @@ Status<std::shared_ptr<DirectoryEntry>> LookupDirEntry(Process &p, int dirfd,
                                                        std::string_view path,
                                                        bool chase_link) {
   if (!PathIsValid(path)) return MakeError(EINVAL);
+  if (path.empty()) {
+    FileTable &ftbl = p.get_file_table();
+    File *f = ftbl.Get(dirfd);
+    if (unlikely(!f)) return MakeError(EBADF);
+    return f->get_dent();
+  }
   Status<std::shared_ptr<IDir>> pathd = GetPathDirAt(p, dirfd, path);
   if (!pathd) return MakeError(pathd);
   bool must_be_dir;
@@ -631,6 +641,44 @@ long usys_stat(const char *path, struct stat *statbuf) {
   if (!tmp) return MakeCError(tmp);
   Status<void> stat = (*tmp)->GetStats(statbuf);
   if (!stat) return MakeCError(stat);
+  return 0;
+}
+
+long usys_statx(int dirfd, const char *pathname_c, int flag, unsigned int mask,
+                struct statx *statxbuf) {
+  if (!pathname_c) return -EFAULT;
+  std::string_view pathname(pathname_c);
+  bool chase_link = !(flag & AT_SYMLINK_NOFOLLOW);
+  bool at_empty_path = flag & AT_EMPTY_PATH;
+  if (pathname.empty() && !at_empty_path) return -ENOENT;
+  Process &p = myproc();
+  Status<std::shared_ptr<Inode>> tmp =
+      LookupInode(p, dirfd, pathname, chase_link);
+  if (!tmp) return MakeCError(tmp);
+  struct stat statbuf;
+  Status<void> stat = (*tmp)->GetStats(&statbuf);
+  if (!stat) return MakeCError(stat);
+
+  memset(statxbuf, 0, sizeof(struct statx));
+  statxbuf->stx_mode = statbuf.st_mode;
+  statxbuf->stx_blksize = statbuf.st_blksize;
+  statxbuf->stx_nlink = statbuf.st_nlink;
+  statxbuf->stx_uid = statbuf.st_uid;
+  statxbuf->stx_gid = statbuf.st_gid;
+  statxbuf->stx_ino = statbuf.st_ino;
+  statxbuf->stx_size = statbuf.st_size;
+  statxbuf->stx_blocks = statbuf.st_blocks;
+  statxbuf->stx_blksize = statbuf.st_blksize;
+  statxbuf->stx_mnt_id = statbuf.st_dev;
+  statxbuf->stx_mask = STATX_BASIC_STATS;
+
+  statxbuf->stx_atime.tv_sec = statbuf.st_atim.tv_sec;
+  statxbuf->stx_atime.tv_nsec = statbuf.st_atim.tv_nsec;
+  statxbuf->stx_mtime.tv_sec = statbuf.st_mtim.tv_sec;
+  statxbuf->stx_mtime.tv_nsec = statbuf.st_mtim.tv_nsec;
+  statxbuf->stx_ctime.tv_sec = statbuf.st_ctim.tv_sec;
+  statxbuf->stx_ctime.tv_nsec = statbuf.st_ctim.tv_nsec;
+
   return 0;
 }
 

--- a/junction/fs/core.cc
+++ b/junction/fs/core.cc
@@ -1036,7 +1036,6 @@ Status<void> InitFs(
 }
 
 ino_t AllocateInodeNumber() {
-  static std::atomic_size_t inos;
   return inos.fetch_add(1, std::memory_order_relaxed) + 1;
 }
 

--- a/junction/fs/dev.cc
+++ b/junction/fs/dev.cc
@@ -16,11 +16,11 @@ namespace {
 
 template <Status<size_t> (*Reader)(std::span<std::byte>, bool),
           Status<size_t> (*Writer)(std::span<const std::byte>)>
-class SpecialFile : public File {
+class SpecialFile : public SeekableFile {
  public:
   SpecialFile(unsigned int flags, FileMode mode,
               std::shared_ptr<DirectoryEntry> dent) noexcept
-      : File(FileType::kSpecial, flags, mode, std::move(dent)) {
+      : SeekableFile(FileType::kSpecial, flags, mode, std::move(dent)) {
     get_poll_source().Init(kPollIn | kPollOut);
   }
   ~SpecialFile() override = default;

--- a/junction/fs/eventfd.cc
+++ b/junction/fs/eventfd.cc
@@ -110,7 +110,7 @@ Status<size_t> EventFDFile::Write(std::span<const std::byte> buf,
   }
 
   val_ += val;
-  get_poll_source().Set(kPollIn);
+  get_poll_source().Set(kPollIn, true /* force notify */);
   if (val_ == UINT64_MAX) get_poll_source().Clear(kPollOut);
   queue_.WakeAll();
   return kEventFdValSize;

--- a/junction/fs/file.cc
+++ b/junction/fs/file.cc
@@ -213,7 +213,7 @@ long usys_ftruncate(int fd, off_t length) {
   return 0;
 }
 
-ssize_t usys_read(int fd, char *buf, size_t len) {
+ssize_t usys_read(int fd, void *buf, size_t len) {
   FileTable &ftbl = myproc().get_file_table();
   File *f = ftbl.Get(fd);
   if (unlikely(!f || !f->is_readable())) return -EBADF;
@@ -232,7 +232,7 @@ ssize_t usys_readv(int fd, struct iovec *iov, int iovcnt) {
   return static_cast<ssize_t>(*ret);
 }
 
-ssize_t usys_write(int fd, const char *buf, size_t len) {
+ssize_t usys_write(int fd, const void *buf, size_t len) {
   FileTable &ftbl = myproc().get_file_table();
   File *f = ftbl.Get(fd);
   if (unlikely(!f || !f->is_writeable())) return -EBADF;
@@ -241,7 +241,7 @@ ssize_t usys_write(int fd, const char *buf, size_t len) {
   return static_cast<ssize_t>(*ret);
 }
 
-ssize_t usys_pread64(int fd, char *buf, size_t len, off_t offset) {
+ssize_t usys_pread64(int fd, void *buf, size_t len, off_t offset) {
   FileTable &ftbl = myproc().get_file_table();
   File *f = ftbl.Get(fd);
   if (unlikely(!f || !f->is_readable())) return -EBADF;
@@ -269,9 +269,7 @@ Status<size_t> File::Writev(std::span<const iovec> vec, off_t *off) {
   Status<size_t> ret;
   for (auto &v : vec) {
     if (!v.iov_len) continue;
-    ret = Write(
-        writable_span(reinterpret_cast<const char *>(v.iov_base), v.iov_len),
-        off);
+    ret = Write(writable_span(v), off);
     if (!ret) break;
     total_bytes += *ret;
     if (*ret < v.iov_len) break;
@@ -285,8 +283,7 @@ Status<size_t> File::Readv(std::span<iovec> vec, off_t *off) {
   Status<size_t> ret;
   for (auto &v : vec) {
     if (!v.iov_len) continue;
-    ret = Read(readable_span(reinterpret_cast<char *>(v.iov_base), v.iov_len),
-               off);
+    ret = Read(readable_span(v), off);
     if (!ret) break;
     total_bytes += *ret;
     if (!is_nonblocking() || *ret < v.iov_len) break;
@@ -519,7 +516,7 @@ ssize_t usys_pwritev2(int fd, const iovec *iov, int iovcnt, off_t offset,
   return static_cast<ssize_t>(*ret);
 }
 
-ssize_t usys_pwrite64(int fd, const char *buf, size_t len, off_t offset) {
+ssize_t usys_pwrite64(int fd, const void *buf, size_t len, off_t offset) {
   FileTable &ftbl = myproc().get_file_table();
   File *f = ftbl.Get(fd);
   if (unlikely(!f || !f->is_writeable())) return -EBADF;

--- a/junction/fs/file.cc
+++ b/junction/fs/file.cc
@@ -82,6 +82,8 @@ void FileTable::Resize(size_t len) {
     rt::RCUFree(std::move(farr_));
     farr_ = std::move(narr);
     close_on_exec_.resize(new_cap);
+  } else {
+    farr_->len = len;
   }
 }
 

--- a/junction/fs/file.cc
+++ b/junction/fs/file.cc
@@ -37,6 +37,9 @@ namespace detail {
 void file_desc::OnDescriptorClose(file_desc::close_handle &handle) {
   // Note that fd number may be reused at this point, only use in situations
   // where that race is OK.
+
+  // TODO: better way of mapping file tables to procfs's.
+  if (!IsJunctionThread()) return;
   myproc().get_procfs().NotifyFDDestroy(handle.fd);
   Inode *ino = handle.file->get_inode();
   if (ino) ino->NotifyDescriptorClosed(myproc());
@@ -359,7 +362,7 @@ Status<long> File::Ioctl(unsigned long request, char *argp) {
 }
 
 void File::save_dent_path(cereal::BinaryOutputArchive &ar) const {
-  Status<std::string> ret = get_dent_ref().GetPathStr();
+  Status<std::string> ret = get_dent_ref().GetPathStr(FSRoot::GetGlobalRoot());
   if (!ret) throw std::runtime_error("stale file handle");
   ar(*ret);
 }
@@ -443,13 +446,13 @@ File::File(FileType type, unsigned int flags, FileMode mode,
       ino_(&ent->get_inode_ref()),
       dent_(std::move(ent)) {}
 
-[[nodiscard]] std::string File::get_filename() const {
+[[nodiscard]] std::string File::get_filename(const FSRoot &fs) const {
   if (!dent_) return "";
   std::string out;
   out.reserve(PATH_MAX);
   rt::RuntimeLibcGuard g;
   std::ostringstream ss(std::move(out));
-  Status<void> ret = dent_->GetFullPath(ss);
+  Status<void> ret = dent_->GetFullPath(fs, ss);
   if (unlikely(!ret)) return "[STALE]";
   return ss.str();
 }

--- a/junction/fs/file.cc
+++ b/junction/fs/file.cc
@@ -689,11 +689,14 @@ long usys_fcntl(int fd, unsigned int cmd, unsigned long arg) {
       else
         return -EINVAL;
       return 0;
-    case F_GETFL:
-      return ToFlags(f->get_mode()) | f->get_flags();
+    case F_GETFL: {
+      int flags = ToFlags(f->get_mode()) | f->get_flags();
+      if (f->get_type() == FileType::kPath) flags |= O_PATH;
+      return flags;
+    }
     case F_SETFL:
       arg &= ~(O_RDONLY | O_WRONLY | O_RDWR | O_CREAT | O_EXCL | O_NOCTTY |
-               O_TRUNC);
+               O_TRUNC | O_PATH);
       if (arg & ~kFlagNonblock)
         LOG_ONCE(WARN) << "fcntl: F_SETFL ignoring some flags " << arg;
       f->set_flags((f->get_flags() & ~kFlagNonblock) | (arg & kFlagNonblock));

--- a/junction/fs/file.h
+++ b/junction/fs/file.h
@@ -33,6 +33,7 @@ enum class FileType : int {
   kSymlink,
   kInotify,
   kSignalFd,
+  kPath,
 };
 
 //

--- a/junction/fs/file.h
+++ b/junction/fs/file.h
@@ -101,6 +101,8 @@ inline constexpr unsigned int ToFlags(FileMode mode) {
   return static_cast<unsigned int>(mode);
 }
 
+class FSRoot;
+
 //
 // Seek from operations.
 //
@@ -205,7 +207,7 @@ class File : public std::enable_shared_from_this<File> {
 
   [[nodiscard]] DirectoryEntry &get_dent_ref() const { return *dent_.get(); }
   [[nodiscard]] bool has_dent() const { return !!dent_; }
-  [[nodiscard]] virtual std::string get_filename() const;
+  [[nodiscard]] virtual std::string get_filename(const FSRoot &fs) const;
 
   // There is some limitation in cereal's polymorphic type registration that
   // seems to require base/derived classes to both use save/load or serialize.

--- a/junction/fs/fs.h
+++ b/junction/fs/fs.h
@@ -371,9 +371,10 @@ class DentryMap {
 
   [[nodiscard]] size_t size() const { return dents_.size(); }
 
-  [[nodiscard]] Status<void> MoveFrom(DentryMap &src, std::string_view src_name,
-                                      std::string_view dst_name,
-                                      bool overwrite) {
+  [[nodiscard]] Status<void> MoveFrom(
+      DentryMap &src, std::string_view src_name, std::string_view dst_name,
+      bool overwrite,
+      std::function<void(DirectoryEntry *)> on_success = nullptr) {
     assert_locked();
     assert(src.getdir().lock_.IsHeld());
 
@@ -412,6 +413,8 @@ class DentryMap {
       dents_.insert_commit(*dent, commit_data);
       dent->parent_.store(getdir().get_entry(), std::memory_order_relaxed);
     }
+
+    if (on_success) on_success(dent);
 
     return {};
   }

--- a/junction/fs/fs.h
+++ b/junction/fs/fs.h
@@ -547,6 +547,11 @@ class IDir : public Inode, protected DentryMap<IDir> {
   // Create makes a new normal file.
   virtual Status<std::shared_ptr<File>> Create(std::string_view name, int flags,
                                                mode_t mode, FileMode fmode) = 0;
+  // CreateTemp creates a new temporary file.
+  virtual Status<std::shared_ptr<File>> CreateTemp(int flags, mode_t mode,
+                                                   FileMode fmode) {
+    return MakeError(EOPNOTSUPP);
+  };
   // GetDents returns a vector of the current entries.
   virtual std::vector<dir_entry> GetDents() = 0;
 

--- a/junction/fs/fs.h
+++ b/junction/fs/fs.h
@@ -208,14 +208,14 @@ class DirectoryEntry : public std::enable_shared_from_this<DirectoryEntry> {
   }
 
   // Place the full path of this entry into os.
-  [[nodiscard]] Status<void> GetFullPath(std::ostream &os);
+  [[nodiscard]] Status<void> GetFullPath(const FSRoot &fs, std::ostream &os);
 
   // Get the full pathname to this directory entry in a string. This slower
   // variant should be used outside of performance critical sections.
-  [[nodiscard]] Status<std::string> GetPathStr() {
+  [[nodiscard]] Status<std::string> GetPathStr(const FSRoot &fs) {
     rt::RuntimeLibcGuard g;
     std::stringstream ss;
-    if (Status<void> ret = GetFullPath(ss); !ret) return MakeError(ret);
+    if (Status<void> ret = GetFullPath(fs, ss); !ret) return MakeError(ret);
     return ss.str();
   }
 
@@ -276,7 +276,9 @@ class DirectoryEntry : public std::enable_shared_from_this<DirectoryEntry> {
     if (intrusive_ref_.use_count() > 1) {
       rt::RuntimeLibcGuard g;
       std::stringstream ss;
-      if (Status<void> ret = GetFullPath(ss); !ret) BUG();
+      // TODO: fixme
+      // if (Status<void> ret = GetFullPath(FSRoot::GetGlobalRoot(), ss); !ret)
+      // BUG();
       ss << " (deleted)";
       rt::SpinGuard g1(lock_);
       name_ = ss.str();

--- a/junction/fs/junction_file.h
+++ b/junction/fs/junction_file.h
@@ -41,7 +41,11 @@ class JunctionFile {
   ~JunctionFile() = default;
 
   // Read from the file.
-  Status<size_t> Read(std::span<std::byte> buf) { return f_->Read(buf, &off_); }
+  Status<size_t> Read(std::span<std::byte> buf) {
+    Status<size_t> ret = f_->Read(buf, &off_);
+    if (ret && *ret == 0) return MakeError(EUNEXPECTEDEOF);
+    return ret;
+  }
 
   // Write to the file.
   Status<size_t> Write(std::span<const std::byte> buf) {

--- a/junction/fs/linuxfs/dir.cc
+++ b/junction/fs/linuxfs/dir.cc
@@ -199,7 +199,23 @@ Status<void> LinuxWrIDir::DoRename(LinuxWrIDir &src, std::string_view src_name,
                                           linux_root_fd, dst_path, replace);
   if (!ret) return ret;
 
-  if (src.is_initialized()) return MoveFrom(src, src_name, dst_name, replace);
+  if (src.is_initialized()) {
+    // This is pretty hacky, maybe we can come up with a better design if the
+    // writeable linuxfs becomes more important.
+    auto on_success = [this, &dst_path](DirectoryEntry *dent) {
+      Inode *inode = &dent->get_inode_ref();
+      // TODO: this is also possibly race-y, should consider protecting the
+      // path_ with rcu.
+      if (inode->is_dir()) {
+        LinuxWrIDir *dir = fast_cast<LinuxWrIDir *>(inode);
+        dir->path_ = dst_path;
+      } else if (inode->is_regular()) {
+        LinuxInode *file = fast_cast<LinuxInode *>(inode);
+        file->path_ = dst_path;
+      }
+    };
+    return MoveFrom(src, src_name, dst_name, replace, on_success);
+  }
 
   if (!is_initialized()) return {};
 

--- a/junction/fs/linuxfs/dir.cc
+++ b/junction/fs/linuxfs/dir.cc
@@ -99,13 +99,13 @@ Status<DirectoryEntry *> LinuxIDir::AddInode(const struct stat &stat,
 
   std::shared_ptr<Inode> ino;
 
-  if (S_ISREG(stat.st_mode)) {
-    ino = std::make_shared<LinuxInode>(stat, std::move(abspath));
-  } else if (S_ISLNK(stat.st_mode)) {
+  if (S_ISLNK(stat.st_mode)) {
     char buf[PATH_MAX];
     Status<std::string_view> target = linux_root_fd.ReadLinkAt(abspath, {buf});
     if (!target) return MakeError(target);
     ino = std::make_shared<LinuxISoftLink>(stat, std::string(*target));
+  } else {
+    ino = std::make_shared<LinuxInode>(stat, std::move(abspath));
   }
 
   if (ino) return AddDentLockedNoCheck(std::string(entry_name), std::move(ino));

--- a/junction/fs/linuxfs/linuxfs.cc
+++ b/junction/fs/linuxfs/linuxfs.cc
@@ -41,14 +41,33 @@ Status<void> LinuxInode::SetSize(size_t size) {
 }
 
 Status<void> MountLinux(IDir &parent, std::string name, std::string_view path) {
-  struct stat buf;
-  int ret = ksys_newfstatat(AT_FDCWD, path.data(), &buf, AT_EMPTY_PATH);
-  if (ret) return MakeError(-ret);
-  allowed_devs.insert(buf.st_dev);
-  if constexpr (linux_fs_writeable())
-    parent.AddIDirNoCheck<LinuxWrIDir>(std::move(name), buf, std::string(path));
-  else
-    parent.AddIDirNoCheck<LinuxIDir>(std::move(name), buf, std::string(path));
+  Status<KernelStatBuf> tmp = KernelStat(path.data());
+  if (!tmp) return MakeError(tmp);
+
+  KernelStatBuf &buf = *tmp;
+
+  if (buf.is_directory()) {
+    allowed_devs.insert(buf.st_dev());
+    if constexpr (linux_fs_writeable())
+      parent.AddIDirNoCheck<LinuxWrIDir>(std::move(name), buf,
+                                         std::string(path));
+    else
+      parent.AddIDirNoCheck<LinuxIDir>(std::move(name), buf, std::string(path));
+    return {};
+  }
+
+  std::shared_ptr<Inode> ino;
+
+  if (buf.is_symlink()) {
+    char buf2[PATH_MAX];
+    Status<std::string_view> target = linux_root_fd.ReadLinkAt(path, {buf2});
+    if (!target) return MakeError(target);
+    ino = std::make_shared<LinuxISoftLink>(buf, std::string(*target));
+  } else {
+    ino = std::make_shared<LinuxInode>(buf, std::string(path));
+  }
+
+  parent.Link(std::move(name), std::move(ino));
   return {};
 }
 

--- a/junction/fs/linuxfs/linuxfs.h
+++ b/junction/fs/linuxfs/linuxfs.h
@@ -64,7 +64,8 @@ class LinuxInode : public Inode {
   [[nodiscard]] Status<void> SetSize(size_t sz) override;
 
  private:
-  const std::string path_;
+  friend class LinuxWrIDir;
+  std::string path_;
   const off_t size_;
   const time_t mtime_;
   const dev_t dev_;
@@ -121,7 +122,7 @@ class LinuxIDir : public memfs::MemIDir {
     return result;
   }
 
-  const std::string path_;
+  std::string path_;
 };
 
 class LinuxWrIDir : public LinuxIDir {

--- a/junction/fs/memfs/dir.cc
+++ b/junction/fs/memfs/dir.cc
@@ -115,6 +115,15 @@ Status<std::shared_ptr<DirectoryEntry>> MemIDir::LinkReturn(
   return AddDentLockedReturn(std::string(name), std::move(ino));
 }
 
+Status<std::shared_ptr<File>> MemIDir::CreateTemp(int flags, mode_t mode,
+                                                  FileMode fmode) {
+  Status<std::shared_ptr<MemInode>> ino = MemInode::Create(mode);
+  if (unlikely(!ino)) return MakeError(ino);
+  auto sp = std::make_shared<DirectoryEntry>(
+      std::string{}, std::shared_ptr<DirectoryEntry>{}, std::move(*ino));
+  return sp->Open(flags, fmode);
+}
+
 Status<std::shared_ptr<File>> MemIDir::Create(std::string_view name, int flags,
                                               mode_t mode, FileMode fmode) {
   DoInitCheck();

--- a/junction/fs/memfs/memfs.cc
+++ b/junction/fs/memfs/memfs.cc
@@ -11,6 +11,7 @@ extern "C" {
 #include "junction/kernel/ksys.h"
 
 #ifndef MFD_EXEC
+#define MFD_EXEC 0
 #define MFD_FLAGS 0
 #else
 #define MFD_FLAGS MFD_EXEC
@@ -172,7 +173,10 @@ std::shared_ptr<Inode> CreateIDevice(dev_t dev, mode_t mode) {
 
 Status<void> InitMemfs() {
   memfs_extent_fd = memfd_create("memfs", MFD_FLAGS);
-  if (memfs_extent_fd < 0) return MakeError(errno);
+  if (memfs_extent_fd < 0) {
+    memfs_extent_fd = memfd_create("memfs", MFD_FLAGS & ~MFD_EXEC);
+    if (memfs_extent_fd < 0) return MakeError(errno);
+  }
 
   int ret = ftruncate(memfs_extent_fd, kMaxMemfdExtent);
   if (ret < 0) return MakeError(errno);

--- a/junction/fs/memfs/memfs.h
+++ b/junction/fs/memfs/memfs.h
@@ -14,9 +14,9 @@ namespace junction::memfs {
 
 inline constexpr __fsword_t TMPFS_MAGIC = 0x01021994;
 inline constexpr size_t kBlockSize = 4096;
-inline constexpr size_t kMaxSizeBytes = (1UL << 30);                  // 1 GB
+inline constexpr size_t kMaxSizeBytes = (1UL << 28);                  // 256 MB
 inline constexpr size_t kMaxMemfdExtent = (1UL << 45);                // 35 TB
-inline constexpr size_t kMaxFiles = kMaxMemfdExtent / kMaxSizeBytes;  // 32K
+inline constexpr size_t kMaxFiles = kMaxMemfdExtent / kMaxSizeBytes;  // 128K
 
 inline void StatFs(struct statfs *buf) {
   buf->f_type = TMPFS_MAGIC;
@@ -180,6 +180,8 @@ class MemIDir : public IDir {
 
   Status<std::shared_ptr<File>> Create(std::string_view name, int flags,
                                        mode_t mode, FileMode fmode) override;
+  Status<std::shared_ptr<File>> CreateTemp(int flags, mode_t mode,
+                                           FileMode fmode) override;
   std::vector<dir_entry> GetDents() override;
 
   // Inode ops

--- a/junction/fs/pipe.h
+++ b/junction/fs/pipe.h
@@ -188,6 +188,10 @@ class WaitableChannel {
   [[nodiscard]] bool is_empty() const { return chan_.is_empty(); }
   [[nodiscard]] bool is_full() const { return chan_.is_full(); }
 
+  [[nodiscard]] Status<size_t> get_readable_bytes() const {
+    return chan_.get_readable_bytes();
+  }
+
  private:
   [[nodiscard]] bool reader_is_closed() const {
     return reader_closed_.load(std::memory_order_acquire);

--- a/junction/fs/poll.h
+++ b/junction/fs/poll.h
@@ -93,7 +93,7 @@ class alignas(kCacheLineSize) PollSource {
   }
 
   // Sets a mask of events and notifies (must be synchronized by caller).
-  void Set(unsigned int event_mask);
+  void Set(unsigned int event_mask, bool force_notify = false);
 
   // Clears a mask of events and notifies (must be synchronized by caller).
   void Clear(unsigned int event_mask);
@@ -184,9 +184,9 @@ class SinglePollSource {
   PollSource *source_{nullptr};
 };
 
-inline void PollSource::Set(unsigned int event_mask) {
+inline void PollSource::Set(unsigned int event_mask, bool force_notify) {
   unsigned int cur = event_mask_;
-  if ((cur & event_mask) == event_mask) return;
+  if ((cur & event_mask) == event_mask && !force_notify) return;
   event_mask_ = cur | event_mask;
   Notify();
 }

--- a/junction/fs/procfs/procfs.cc
+++ b/junction/fs/procfs/procfs.cc
@@ -261,8 +261,9 @@ class FDDir : public ProcFSDir {
     if (fds_with_symlink_inodes_.size() <= static_cast<size_t>(fd))
       fds_with_symlink_inodes_.resize(1 + fd * 2);
     fds_with_symlink_inodes_.set(fd);
-    return AddDentLockedNoCheck(std::to_string(fd),
-                                std::make_shared<ProcFSLink>(f.get_filename()));
+    return AddDentLockedNoCheck(
+        std::to_string(fd),
+        std::make_shared<ProcFSLink>(f.get_filename(FSRoot::GetGlobalRoot())));
   }
 
   void DeleteEntry(int fd) {

--- a/junction/fs/procfs/procfs.cc
+++ b/junction/fs/procfs/procfs.cc
@@ -57,6 +57,30 @@ std::string GetMounts() {
   return "tmpfs / tmpfs rw,nosuid,nodev,inode64 0 0\n";
 }
 
+// /proc/net/snmp
+std::string GetSNMPInfo() {
+  static std::string snmp_info = R"(
+Ip: Forwarding DefaultTTL InReceives InHdrErrors InAddrErrors ForwDatagrams InUnknownProtos InDiscards InDelivers OutRequests OutDiscards OutNoRoutes ReasmTimeout ReasmReqds ReasmOKs ReasmFails FragOKs FragFails FragCreates OutTransmits
+Ip: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+Icmp: InMsgs InErrors InCsumErrors InDestUnreachs InTimeExcds InParmProbs InSrcQuenchs InRedirects InEchos InEchoReps InTimestamps InTimestampReps InAddrMasks InAddrMaskReps OutMsgs OutErrors OutRateLimitGlobal OutRateLimitHost OutDestUnreachs OutTimeExcds OutParmProbs OutSrcQuenchs OutRedirects OutEchos OutEchoReps OutTimestamps OutTimestampReps OutAddrMasks OutAddrMaskReps
+Icmp: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+IcmpMsg: InType0 InType3 InType8 OutType0 OutType3 OutType8
+IcmpMsg: 0 0 0 0 0 0
+Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+Tcp: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+Udp: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti MemErrors
+Udp: 0 0 0 0 0 0 0 0 0
+UdpLite: InDatagrams NoPorts InErrors OutDatagrams RcvbufErrors SndbufErrors InCsumErrors IgnoredMulti MemErrors
+UdpLite: 0 0 0 0 0 0 0 0 0)";
+  return snmp_info;
+}
+// /proc/net/dev
+std::string GetDev() {
+  return R"(Inter-|   Receive                                                |  Transmit
+ face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+      eth0: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)";
+}
+
 std::optional<int> ParseInt(std::string_view s) {
   int result;
   if (std::from_chars(s.data(), s.data() + s.size(), result).ec == std::errc{})
@@ -337,6 +361,19 @@ class TaskDir : public ProcFSDir {
 };
 
 // /proc/<pid>
+class ProcFSNetDir : public ProcFSDir {
+ public:
+  ProcFSNetDir(Token t) : ProcFSDir(t, 0555) {}
+  ~ProcFSNetDir() override = default;
+
+ protected:
+  void DoInitialize() override {
+    AddDentLockedNoCheck("snmp", MakeInode(0444, GetSNMPInfo));
+    AddDentLockedNoCheck("dev", MakeInode(0444, GetDev));
+  }
+};
+
+// /proc/<pid>
 class ProcessDir : public ProcFSDir {
  public:
   ProcessDir(Token t, Process &p)
@@ -524,6 +561,7 @@ class ProcRootDir : public ProcFSDir {
     AddDentLockedNoCheck("meminfo", MakeInode(0444, GetMemInfo));
     AddDentLockedNoCheck("mounts", MakeInode(0444, GetMounts));
     AddDentLockedNoCheck("stat", MakeInode(0444, GetStat));
+    AddIDirLockedNoCheck<ProcFSNetDir>("net");
   }
 
  private:

--- a/junction/fs/procfs/procfs.cc
+++ b/junction/fs/procfs/procfs.cc
@@ -372,6 +372,10 @@ class ProcessDir : public ProcFSDir {
     AddDentLockedNoCheck(
         "stat", MakeInode(0444, [p = proc_] { return GetProcStat(p); }));
 
+    DirectoryEntry *dx = AddIDirLockedNoCheck<ProcFSDir>("ns", 0555);
+    static_cast<ProcFSDir &>(dx->get_inode_ref())
+        .Link("pid", MakeInode(0444, [p = proc_] { return ""; }));
+
     DirectoryEntry *de = AddIDirLockedNoCheck<FDDir>(std::string(kFDDirName));
     fd_dir_ =
         static_cast<FDDir &>(de->get_inode_ref()).shared_from_base<FDDir>();

--- a/junction/fs/procfs/procfs.cc
+++ b/junction/fs/procfs/procfs.cc
@@ -59,6 +59,7 @@ std::string GetMounts() {
 
 // /proc/net/snmp
 std::string GetSNMPInfo() {
+  rt::RuntimeLibcGuard g;
   static std::string snmp_info = R"(
 Ip: Forwarding DefaultTTL InReceives InHdrErrors InAddrErrors ForwDatagrams InUnknownProtos InDiscards InDelivers OutRequests OutDiscards OutNoRoutes ReasmTimeout ReasmReqds ReasmOKs ReasmFails FragOKs FragFails FragCreates OutTransmits
 Ip: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
@@ -76,6 +77,7 @@ UdpLite: 0 0 0 0 0 0 0 0 0)";
 }
 // /proc/net/dev
 std::string GetDev() {
+  rt::RuntimeLibcGuard g;
   return R"(Inter-|   Receive                                                |  Transmit
  face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
       eth0: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)";

--- a/junction/fs/stdiofile.cc
+++ b/junction/fs/stdiofile.cc
@@ -43,7 +43,7 @@ Status<void> StdIOFile::Sync() {
 }
 
 void StdIOFile::save(cereal::BinaryOutputArchive &ar) const {
-  Status<std::string> ret = get_dent_ref().GetPathStr();
+  Status<std::string> ret = get_dent_ref().GetPathStr(FSRoot::GetGlobalRoot());
   if (!ret) throw std::runtime_error("stale linuxfile handle");
   ar(get_flags(), get_mode(), *ret);
   ar(cereal::base_class<File>(this));

--- a/junction/junction.cc
+++ b/junction/junction.cc
@@ -165,8 +165,8 @@ Status<void> JunctionCfg::FillFromArgs(int argc, char *argv[]) {
   snapshot_on_stop_ = vm["snapshot-on-stop"].as<int>();
   expecting_snapshot_ = vm["snapshot_enabled"].as<bool>();
   expecting_snapshot_ |= snapshot_on_stop_;
-  expecting_snapshot_ |= vm.count("function_arg") && !restore;
-  function_name_ = vm["function_name"].as<std::string>();
+  expecting_snapshot_ |=
+      vm["function_arg"].as<std::string>().size() > 0 && !restore;
 
   uid_ = vm["uid"].as<uid_t>();
   gid_ = vm["gid"].as<uid_t>();
@@ -183,10 +183,9 @@ Status<void> JunctionCfg::FillFromArgs(int argc, char *argv[]) {
   madv_remap = vm["madv_remap"].as<bool>();
   kernel_restoring_ = vm["kernel-restore"].as<bool>();
   jif_ = vm["jif"].as<bool>();
-  snapshot_prefix_ = vm["snapshot-prefix"].as<std::string>();
   cache_linux_fs_ = vm["cache_linux_fs"].as<bool>();
   port_ = vm["port"].as<int>();
-  if (snapshot_on_stop_ && snapshot_prefix_.empty()) {
+  if (snapshot_on_stop_ && vm["snapshot-prefix"].as<std::string>().empty()) {
     std::cerr << "need a snapshot prefix if we are snapshotting" << std::endl;
     return MakeError(EINVAL);
   }

--- a/junction/junction.cc
+++ b/junction/junction.cc
@@ -240,16 +240,28 @@ Status<void> init() {
   linux_pid = getpid();
 
   Status<void> ret = InitSignal();
-  if (unlikely(!ret)) return ret;
+  if (unlikely(!ret)) {
+    LOG(ERR) << "failed to initialize signal: " << ret.error();
+    return ret;
+  }
 
   ret = SyscallInit();
-  if (unlikely(!ret)) return ret;
+  if (unlikely(!ret)) {
+    LOG(ERR) << "failed to initialize syscall: " << ret.error();
+    return ret;
+  }
 
   ret = InitZpoline();
-  if (unlikely(!ret)) return ret;
+  if (unlikely(!ret)) {
+    LOG(ERR) << "failed to initialize zpoline: " << ret.error();
+    return ret;
+  }
 
   ret = InitChroot();
-  if (unlikely(!ret)) return ret;
+  if (unlikely(!ret)) {
+    LOG(ERR) << "failed to initialize chroot: " << ret.error();
+    return ret;
+  }
 
   char *dropuid = getenv("DROP_PRIV_UID");
   if (dropuid) {
@@ -261,19 +273,34 @@ Status<void> init() {
   }
 
   ret = InitFs(linux_mount_points, GetFsMounts());
-  if (unlikely(!ret)) return ret;
+  if (unlikely(!ret)) {
+    LOG(ERR) << "failed to initialize fs: " << ret.error();
+    return ret;
+  }
 
   ret = ShimJmpInit();
-  if (unlikely(!ret)) return ret;
+  if (unlikely(!ret)) {
+    LOG(ERR) << "failed to initialize shim: " << ret.error();
+    return ret;
+  }
 
   ret = InitUnixTime();
-  if (unlikely(!ret)) return ret;
+  if (unlikely(!ret)) {
+    LOG(ERR) << "failed to initialize unix time: " << ret.error();
+    return ret;
+  }
 
   ret = init_seccomp();
-  if (unlikely(!ret)) return ret;
+  if (unlikely(!ret)) {
+    LOG(ERR) << "failed to initialize seccomp: " << ret.error();
+    return ret;
+  }
 
   ret = InitControlServer();
-  if (unlikely(!ret)) return ret;
+  if (unlikely(!ret)) {
+    LOG(ERR) << "failed to initialize control server: " << ret.error();
+    return ret;
+  }
 
   return InitChannelClient();
 }

--- a/junction/junction.h
+++ b/junction/junction.h
@@ -65,16 +65,9 @@ class alignas(kCacheLineSize) JunctionCfg {
     return terminate_after_snapshot_;
   }
   [[nodiscard]] uint16_t port() const { return port_; }
-  [[nodiscard]] const std::string &get_snapshot_prefix() const {
-    return snapshot_prefix_;
-  }
 
   [[nodiscard]] bool using_chroot() const { return chroot_path.size() > 0; }
   [[nodiscard]] bool zpoline() const { return zpoline_; }
-
-  [[nodiscard]] const std::string &get_function_name() const {
-    return function_name_;
-  }
 
   static void PrintOptions();
   Status<void> FillFromArgs(int argc, char *argv[]);
@@ -112,8 +105,6 @@ class alignas(kCacheLineSize) JunctionCfg {
   bool terminate_after_snapshot_;
   int snapshot_on_stop_;
   bool mem_trace_;
-  std::string snapshot_prefix_;
-  std::string function_name_;
   static JunctionCfg singleton_;
 };
 

--- a/junction/kernel/exec.cc
+++ b/junction/kernel/exec.cc
@@ -254,7 +254,7 @@ Status<ExecInfo> Exec(Process &p, MemoryMap &mm, std::string_view pathname,
   if (!ret) return MakeError(ret);
 
   if (unlikely(GetCfg().strace_enabled())) {
-    Status<std::string> filename = ctx.file.get_dent()->GetPathStr();
+    Status<std::string> filename = ctx.file.get_dent()->GetPathStr(ctx.fs);
     BUG_ON(!filename);
     LogSyscallDirect("execve", *filename, ctx.get_argv_view(), envp);
   }

--- a/junction/kernel/exec.cc
+++ b/junction/kernel/exec.cc
@@ -7,6 +7,7 @@ extern "C" {
 #include <sys/auxv.h>
 
 #include "lib/caladan/runtime/defs.h"
+#include "linux_rseq.h"
 }
 
 #include <cstring>
@@ -23,6 +24,11 @@ extern "C" {
 #include "junction/syscall/strace.h"
 #include "junction/syscall/syscall.h"
 #include "junction/syscall/vdso.h"
+
+#ifndef AT_RSEQ_FEATURE_SIZE
+#define AT_RSEQ_FEATURE_SIZE 27 /* rseq supported feature size */
+#define AT_RSEQ_ALIGN 28        /* rseq allocation alignment */
+#endif
 
 namespace junction {
 namespace {

--- a/junction/kernel/exec.cc
+++ b/junction/kernel/exec.cc
@@ -307,8 +307,7 @@ long DoExecve(std::shared_ptr<DirectoryEntry> dent, const char *filename,
     if (replace_non_reloc) {
       // Log while the memory is still available.
       if (unlikely(GetCfg().strace_enabled()))
-        LogSyscall("execve", &usys_execve, (strace::PathName *)filename, argv,
-                   envp);
+        LogSyscallDirect("execve", (strace::PathName *)filename, argv, envp);
 
       ctx.TakeArgvOwnership();
 
@@ -339,8 +338,8 @@ long DoExecve(std::shared_ptr<DirectoryEntry> dent, const char *filename,
 
     // The syscall has suceeded.
     if (unlikely(GetCfg().strace_enabled() && !replace_non_reloc))
-      LogSyscall(0, "execve", &usys_execve, (strace::PathName *)filename, argv,
-                 envp);
+      LogSyscallDirect((long)0, std::string_view("execve"),
+                       (strace::PathName *)filename, argv, envp);
 
     // Reset rseq since its memory may become invalid (and may be accessed if
     // preemption occurs).

--- a/junction/kernel/ksys.h
+++ b/junction/kernel/ksys.h
@@ -353,11 +353,27 @@ inline Status<void *> KernelMRemap(void *old_addr, size_t old_sz,
   return reinterpret_cast<void *>(ret);
 }
 
-// Get file status.
-inline Status<void> KernelStat(const char *path, struct stat *buf) {
-  int ret = ksys_newfstatat(AT_FDCWD, path, buf, 0);
-  if (ret < 0) return MakeError(-ret);
-  return {};
+// A wrapper around a struct stat that prevents zeroing on construction.
+struct KernelStatBuf {
+  struct stat s;
+  KernelStatBuf() noexcept { /* do nothing */
+  }
+  operator struct stat &() { return s; }
+  operator const struct stat &() const { return s; }
+  struct stat *ptr() { return &s; }
+
+  [[nodiscard]] bool is_directory() const { return S_ISDIR(s.st_mode); }
+  [[nodiscard]] bool is_symlink() const { return S_ISLNK(s.st_mode); }
+  [[nodiscard]] bool is_regular() const { return S_ISREG(s.st_mode); }
+
+  [[nodiscard]] dev_t st_dev() const { return s.st_dev; }
+};
+
+inline Status<KernelStatBuf> KernelStat(const char *path) {
+  Status<KernelStatBuf> res;
+  int ret = ksys_newfstatat(AT_FDCWD, path, res->ptr(), 0);
+  if (ret < 0) res = MakeError(-ret);
+  return res;
 }
 
 }  // namespace junction

--- a/junction/kernel/ksys.h
+++ b/junction/kernel/ksys.h
@@ -356,8 +356,7 @@ inline Status<void *> KernelMRemap(void *old_addr, size_t old_sz,
 // A wrapper around a struct stat that prevents zeroing on construction.
 struct KernelStatBuf {
   struct stat s;
-  KernelStatBuf() noexcept { /* do nothing */
-  }
+  KernelStatBuf() noexcept { /* do nothing */ }
   operator struct stat &() { return s; }
   operator const struct stat &() const { return s; }
   struct stat *ptr() { return &s; }

--- a/junction/kernel/linux_rseq.h
+++ b/junction/kernel/linux_rseq.h
@@ -1,0 +1,158 @@
+// clang-format off
+/* SPDX-License-Identifier: GPL-2.0+ WITH Linux-syscall-note */
+#ifndef _LINUX_RSEQ_H
+#define _LINUX_RSEQ_H
+
+/*
+ * linux/rseq.h
+ *
+ * Restartable sequences system call API
+ *
+ * Copyright (c) 2015-2018 Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+ */
+
+#include <linux/types.h>
+#include <asm/byteorder.h>
+
+enum rseq_cpu_id_state {
+	RSEQ_CPU_ID_UNINITIALIZED		= -1,
+	RSEQ_CPU_ID_REGISTRATION_FAILED		= -2,
+};
+
+enum rseq_flags {
+	RSEQ_FLAG_UNREGISTER = (1 << 0),
+};
+
+enum rseq_cs_flags_bit {
+	RSEQ_CS_FLAG_NO_RESTART_ON_PREEMPT_BIT	= 0,
+	RSEQ_CS_FLAG_NO_RESTART_ON_SIGNAL_BIT	= 1,
+	RSEQ_CS_FLAG_NO_RESTART_ON_MIGRATE_BIT	= 2,
+};
+
+enum rseq_cs_flags {
+	RSEQ_CS_FLAG_NO_RESTART_ON_PREEMPT	=
+		(1U << RSEQ_CS_FLAG_NO_RESTART_ON_PREEMPT_BIT),
+	RSEQ_CS_FLAG_NO_RESTART_ON_SIGNAL	=
+		(1U << RSEQ_CS_FLAG_NO_RESTART_ON_SIGNAL_BIT),
+	RSEQ_CS_FLAG_NO_RESTART_ON_MIGRATE	=
+		(1U << RSEQ_CS_FLAG_NO_RESTART_ON_MIGRATE_BIT),
+};
+
+/*
+ * struct rseq_cs is aligned on 4 * 8 bytes to ensure it is always
+ * contained within a single cache-line. It is usually declared as
+ * link-time constant data.
+ */
+struct rseq_cs {
+	/* Version of this structure. */
+	__u32 version;
+	/* enum rseq_cs_flags */
+	__u32 flags;
+	__u64 start_ip;
+	/* Offset from start_ip. */
+	__u64 post_commit_offset;
+	__u64 abort_ip;
+} __attribute__((aligned(4 * sizeof(__u64))));
+
+/*
+ * struct rseq is aligned on 4 * 8 bytes to ensure it is always
+ * contained within a single cache-line.
+ *
+ * A single struct rseq per thread is allowed.
+ */
+struct rseq {
+	/*
+	 * Restartable sequences cpu_id_start field. Updated by the
+	 * kernel. Read by user-space with single-copy atomicity
+	 * semantics. This field should only be read by the thread which
+	 * registered this data structure. Aligned on 32-bit. Always
+	 * contains a value in the range of possible CPUs, although the
+	 * value may not be the actual current CPU (e.g. if rseq is not
+	 * initialized). This CPU number value should always be compared
+	 * against the value of the cpu_id field before performing a rseq
+	 * commit or returning a value read from a data structure indexed
+	 * using the cpu_id_start value.
+	 */
+	__u32 cpu_id_start;
+	/*
+	 * Restartable sequences cpu_id field. Updated by the kernel.
+	 * Read by user-space with single-copy atomicity semantics. This
+	 * field should only be read by the thread which registered this
+	 * data structure. Aligned on 32-bit. Values
+	 * RSEQ_CPU_ID_UNINITIALIZED and RSEQ_CPU_ID_REGISTRATION_FAILED
+	 * have a special semantic: the former means "rseq uninitialized",
+	 * and latter means "rseq initialization failed". This value is
+	 * meant to be read within rseq critical sections and compared
+	 * with the cpu_id_start value previously read, before performing
+	 * the commit instruction, or read and compared with the
+	 * cpu_id_start value before returning a value loaded from a data
+	 * structure indexed using the cpu_id_start value.
+	 */
+	__u32 cpu_id;
+	/*
+	 * Restartable sequences rseq_cs field.
+	 *
+	 * Contains NULL when no critical section is active for the current
+	 * thread, or holds a pointer to the currently active struct rseq_cs.
+	 *
+	 * Updated by user-space, which sets the address of the currently
+	 * active rseq_cs at the beginning of assembly instruction sequence
+	 * block, and set to NULL by the kernel when it restarts an assembly
+	 * instruction sequence block, as well as when the kernel detects that
+	 * it is preempting or delivering a signal outside of the range
+	 * targeted by the rseq_cs. Also needs to be set to NULL by user-space
+	 * before reclaiming memory that contains the targeted struct rseq_cs.
+	 *
+	 * Read and set by the kernel. Set by user-space with single-copy
+	 * atomicity semantics. This field should only be updated by the
+	 * thread which registered this data structure. Aligned on 64-bit.
+	 *
+	 * 32-bit architectures should update the low order bits of the
+	 * rseq_cs field, leaving the high order bits initialized to 0.
+	 */
+	__u64 rseq_cs;
+
+	/*
+	 * Restartable sequences flags field.
+	 *
+	 * This field should only be updated by the thread which
+	 * registered this data structure. Read by the kernel.
+	 * Mainly used for single-stepping through rseq critical sections
+	 * with debuggers.
+	 *
+	 * - RSEQ_CS_FLAG_NO_RESTART_ON_PREEMPT
+	 *     Inhibit instruction sequence block restart on preemption
+	 *     for this thread.
+	 * - RSEQ_CS_FLAG_NO_RESTART_ON_SIGNAL
+	 *     Inhibit instruction sequence block restart on signal
+	 *     delivery for this thread.
+	 * - RSEQ_CS_FLAG_NO_RESTART_ON_MIGRATE
+	 *     Inhibit instruction sequence block restart on migration for
+	 *     this thread.
+	 */
+	__u32 flags;
+
+	/*
+	 * Restartable sequences node_id field. Updated by the kernel. Read by
+	 * user-space with single-copy atomicity semantics. This field should
+	 * only be read by the thread which registered this data structure.
+	 * Aligned on 32-bit. Contains the current NUMA node ID.
+	 */
+	__u32 node_id;
+
+	/*
+	 * Restartable sequences mm_cid field. Updated by the kernel. Read by
+	 * user-space with single-copy atomicity semantics. This field should
+	 * only be read by the thread which registered this data structure.
+	 * Aligned on 32-bit. Contains the current thread's concurrency ID
+	 * (allocated uniquely within a memory map).
+	 */
+	__u32 mm_cid;
+
+	/*
+	 * Flexible array member at end of structure, after last feature field.
+	 */
+	char end[];
+} __attribute__((aligned(4 * sizeof(__u64))));
+
+#endif /* _LINUX_RSEQ_H */

--- a/junction/kernel/mm.cc
+++ b/junction/kernel/mm.cc
@@ -92,6 +92,21 @@ bool VMArea::TryMergeRight(const VMArea &lhs) {
   return true;
 }
 
+std::string VMArea::TypeString() const {
+  switch (type) {
+    case VMType::kNormal:
+      return "";
+    case VMType::kHeap:
+      return "[heap]";
+    case VMType::kStack:
+      return "[stack]";
+    case VMType::kFile:
+      return file->get_filename(FSRoot::GetGlobalRoot());
+    default:
+      return "";
+  }
+}
+
 bool MemoryMap::ContainedInMapBounds(void *addr, size_t len) const {
   auto [start, end] = AddressToBounds(addr, len);
   return start >= mm_start_ && end <= mm_end_;
@@ -434,7 +449,7 @@ std::string MemoryMap::get_bin_path() const {
   out.reserve(PATH_MAX);
   rt::RuntimeLibcGuard g;
   std::ostringstream ss(std::move(out));
-  Status<void> ret = binary_path_->GetFullPath(ss);
+  Status<void> ret = binary_path_->GetFullPath(myproc_or_global_fs(), ss);
   if (unlikely(!ret)) return "[STALE]";
   return ss.str();
 }

--- a/junction/kernel/mm.h
+++ b/junction/kernel/mm.h
@@ -63,20 +63,7 @@ struct VMArea {
     return std::min(PageAlign(sz - offset), Length());
   }
 
-  std::string TypeString() const {
-    switch (type) {
-      case VMType::kNormal:
-        return "";
-      case VMType::kHeap:
-        return "[heap]";
-      case VMType::kStack:
-        return "[stack]";
-      case VMType::kFile:
-        return file->get_filename();
-      default:
-        return "";
-    }
-  }
+  std::string TypeString() const;
 
   std::string ProtString() const {
     std::string tmp("---p");

--- a/junction/kernel/proc.cc
+++ b/junction/kernel/proc.cc
@@ -35,6 +35,10 @@ extern "C" {
 #include "junction/syscall/strace.h"
 #include "junction/syscall/syscall.h"
 
+#ifndef P_PIDFD
+#define P_PIDFD 3
+#endif
+
 namespace junction {
 
 inline constexpr uint64_t kThreadRequiredFlags =

--- a/junction/kernel/proc.cc
+++ b/junction/kernel/proc.cc
@@ -354,14 +354,15 @@ bool Process::ThreadFinish(Thread *th) {
   return remaining_threads == 0;
 }
 
-Status<std::pair<std::shared_ptr<Process>, Thread *>> Process::CreateInit() {
+Status<std::pair<std::shared_ptr<Process>, Thread *>> Process::CreateInit(
+    FSRoot &fsr) {
   Status<pid_t> pid = AllocNewSession();
   if (!pid) return MakeError(pid);
 
   Status<std::shared_ptr<MemoryMap>> mm = MemoryMap::Create(kMemoryMappingSize);
   if (!mm) return MakeError(mm);
 
-  auto proc = std::make_shared<Process>(*pid, std::move(*mm));
+  auto proc = std::make_shared<Process>(*pid, std::move(*mm), fsr);
 
   thread_t *th = thread_create(nullptr, 0);
   if (!th) return MakeError(ENOMEM);

--- a/junction/kernel/proc.cc
+++ b/junction/kernel/proc.cc
@@ -182,7 +182,7 @@ long DoClone(clone_args *cl_args, uint64_t rsp) {
       myproc().WaitForFullStop();
     }
     if (unlikely(GetCfg().strace_enabled()))
-      LogSyscall(newth.get_tid(), "vfork", &usys_vfork);
+      LogSyscallDirect(newth.get_tid(), "vfork");
     {
       rt::Preempt::Lock();
       newth.ThreadReady();
@@ -707,7 +707,7 @@ long usys_vfork() {
 
   long ret = DoClone(&cl_args, mythread().GetSyscallFrame().GetRsp());
   if (unlikely(GetCfg().strace_enabled() && ret < 0))
-    LogSyscall(ret, "vfork", &usys_vfork);
+    LogSyscallDirect(ret, "vfork");
 
   return ret;
 }
@@ -720,12 +720,12 @@ long usys_clone3(struct clone_args *cl_args, size_t size) {
     ret = DoClone(cl_args, cl_args->stack + cl_args->stack_size);
 
   if (unlikely(GetCfg().strace_enabled()))
-    LogSyscall(ret, "clone3", &usys_clone,
-               static_cast<strace::CloneFlag>(cl_args->flags),
-               reinterpret_cast<void *>(cl_args->stack),
-               reinterpret_cast<void *>(cl_args->parent_tid),
-               reinterpret_cast<void *>(cl_args->child_tid),
-               reinterpret_cast<void *>(cl_args->tls));
+    LogSyscallDirect(ret, "clone3",
+                     static_cast<strace::CloneFlag>(cl_args->flags),
+                     reinterpret_cast<void *>(cl_args->stack),
+                     reinterpret_cast<void *>(cl_args->parent_tid),
+                     reinterpret_cast<void *>(cl_args->child_tid),
+                     reinterpret_cast<void *>(cl_args->tls));
 
   return ret;
 }
@@ -745,11 +745,11 @@ long usys_clone(unsigned long clone_flags, unsigned long newsp,
 
   long ret = DoClone(&cl_args, newsp);
   if (unlikely(GetCfg().strace_enabled())) {
-    LogSyscall(
-        ret, "clone", &usys_clone, static_cast<strace::CloneFlag>(clone_flags),
-        reinterpret_cast<void *>(newsp),
-        reinterpret_cast<void *>(parent_tidptr),
-        reinterpret_cast<void *>(child_tidptr), reinterpret_cast<void *>(tls));
+    LogSyscallDirect(ret, "clone", static_cast<strace::CloneFlag>(clone_flags),
+                     reinterpret_cast<void *>(newsp),
+                     reinterpret_cast<void *>(parent_tidptr),
+                     reinterpret_cast<void *>(child_tidptr),
+                     reinterpret_cast<void *>(tls));
   }
   return ret;
 }
@@ -781,14 +781,13 @@ __noinline Thread *gdb_mythread() {
 __noinline Process *gdb_myproc() { return &mythread().get_process(); }
 
 [[noreturn]] void usys_exit(int status) {
-  if (unlikely(GetCfg().strace_enabled()))
-    LogSyscall("exit", &usys_exit, status);
+  if (unlikely(GetCfg().strace_enabled())) LogSyscallDirect("exit", status);
   FinishExit(status);
 }
 
 void usys_exit_group(int status) {
   if (unlikely(GetCfg().strace_enabled()))
-    LogSyscall("exit_group", &usys_exit_group, status);
+    LogSyscallDirect("exit_group", status);
   myproc().DoExit(status);
   FinishExit(status);
 }

--- a/junction/kernel/proc.h
+++ b/junction/kernel/proc.h
@@ -582,11 +582,12 @@ class Limits {
 class Process : public std::enable_shared_from_this<Process> {
  public:
   // Constructor for init process
-  Process(pid_t pid, std::shared_ptr<MemoryMap> &&mm)
+  Process(pid_t pid, std::shared_ptr<MemoryMap> &&mm,
+          FSRoot &root = FSRoot::GetGlobalRoot())
       : pid_(pid),
         sid_(pid),
         pgid_(pid),
-        fs_(FSRoot::GetGlobalRoot()),
+        fs_(root),
         mem_map_(std::move(mm)),
         parent_(nullptr) {
     RegisterProcess(*this);
@@ -808,7 +809,8 @@ class Process : public std::enable_shared_from_this<Process> {
     NotifyParentWait(kWaitableContinued);
   }
 
-  static Status<std::pair<std::shared_ptr<Process>, Thread *>> CreateInit();
+  static Status<std::pair<std::shared_ptr<Process>, Thread *>> CreateInit(
+      FSRoot &fsr = FSRoot::GetGlobalRoot());
 
  private:
   friend class cereal::access;
@@ -878,7 +880,7 @@ class Process : public std::enable_shared_from_this<Process> {
     ar(pid_, pgid_, sid_, parent_, file_tbl_, mem_map_, limits_, signal_tbl_,
        shared_sig_q_, child_procs_, wait_state_, wait_status_, it_real_.get());
 
-    Status<std::string> cwd = fs_.get_cwd_ent()->GetPathStr();
+    Status<std::string> cwd = fs_.get_cwd_ent()->GetPathStr(fs_);
     if (!cwd) throw std::runtime_error("stale cwd during snapshot");
     ar(*cwd);
 
@@ -1044,6 +1046,13 @@ inline Thread &mythread() { return Thread::fromCaladanThread(thread_self()); }
 // myproc returns the Process object for the running thread.
 // Behavior is undefined if the running thread is not part of a process.
 inline Process &myproc() { return mythread().get_process(); }
+
+// Returns the FSRoot object for the running thread. If the running thread is
+// not part of a process, returns the global root.
+inline FSRoot &myproc_or_global_fs() {
+  if (IsJunctionThread()) return myproc().get_fs();
+  return FSRoot::GetGlobalRoot();
+}
 
 // SigMaskGuard masks signal delivery during its lifetime. The previous signal
 // mask is restored unless a signal is pending, in which case the old mask is

--- a/junction/kernel/proc.h
+++ b/junction/kernel/proc.h
@@ -153,6 +153,8 @@ struct Credential {
 
 class ThreadRef;
 
+[[noreturn]] void FinishExit(int status);
+
 // Thread is a UNIX thread object.
 class Thread {
  public:

--- a/junction/kernel/rseq.h
+++ b/junction/kernel/rseq.h
@@ -1,7 +1,7 @@
 #pragma once
 
 extern "C" {
-#include <linux/rseq.h>
+#include "linux_rseq.h"
 }
 
 #include "junction/bindings/thread.h"

--- a/junction/kernel/signal.cc
+++ b/junction/kernel/signal.cc
@@ -805,7 +805,7 @@ extern "C" [[noreturn]] void usys_rt_sigreturn_finish(uint64_t rsp) {
   if (unlikely(jframe->magic != kJunctionFrameMagic))
     print_msg_abort("invalid stack frame used in rt_sigreturn");
 
-  if (unlikely(GetCfg().strace_enabled())) LogSyscall("rt_sigreturn");
+  if (unlikely(GetCfg().strace_enabled())) LogSyscallDirect("rt_sigreturn");
 
   // set blocked
   hand.ReplaceMask(sigframe->uc.mask);

--- a/junction/kernel/signal.cc
+++ b/junction/kernel/signal.cc
@@ -1000,6 +1000,11 @@ void ThreadSignalHandler::DeliverSignals(Trapframe &entry, long rax) {
     std::unreachable();
   }
 
+  if (unlikely(myproc().exited())) {
+    FinishExit(0);
+    std::unreachable();
+  }
+
   if (IsRestartSys(rax))
     CheckRestartSysPostHandler(myth.GetSyscallFrame(), rax, *sig);
 

--- a/junction/kernel/usys.h
+++ b/junction/kernel/usys.h
@@ -47,11 +47,11 @@ long usys_renameat2(int olddirfd, const char *oldpath, int newdirfd,
 long usys_unlinkat(int dirfd, const char *pathname, int flags);
 long usys_symlink(const char *target, const char *pathname);
 long usys_symlinkat(const char *target, int dirfd, const char *pathname);
-ssize_t usys_read(int fd, char *buf, size_t len);
+ssize_t usys_read(int fd, void *buf, size_t len);
 ssize_t usys_readv(int fd, struct iovec *iov, int iovcnt);
-ssize_t usys_write(int fd, const char *buf, size_t len);
-ssize_t usys_pread64(int fd, char *buf, size_t len, off_t offset);
-ssize_t usys_pwrite64(int fd, const char *buf, size_t len, off_t offset);
+ssize_t usys_write(int fd, const void *buf, size_t len);
+ssize_t usys_pread64(int fd, void *buf, size_t len, off_t offset);
+ssize_t usys_pwrite64(int fd, const void *buf, size_t len, off_t offset);
 ssize_t usys_writev(int fd, const iovec *iov, int iovcnt);
 ssize_t usys_pwritev(int fd, const iovec *iov, int iovcnt, off_t offset);
 ssize_t usys_pwritev2(int fd, const iovec *iov, int iovcnt, off_t offset,

--- a/junction/kernel/usys.h
+++ b/junction/kernel/usys.h
@@ -71,6 +71,8 @@ long usys_newfstatat(int dirfd, const char *pathname, struct stat *statbuf,
 long usys_statfs(const char *path, struct statfs *buf);
 long usys_fstatfs(int fd, struct statfs *buf);
 long usys_stat(const char *path, struct stat *statbuf);
+long usys_statx(int dirfd, const char *pathname, int flag, unsigned int mask,
+                struct statx *statxbuf);
 long usys_lstat(const char *path, struct stat *statbuf);
 long usys_fstat(int fd, struct stat *statbuf);
 long usys_getdents(unsigned int fd, void *dirp, unsigned int count);

--- a/junction/kernel/usys.h
+++ b/junction/kernel/usys.h
@@ -125,6 +125,8 @@ ssize_t usys_sendmsg(int sockfd, const struct msghdr *msg, int flags);
 ssize_t usys_sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
                       int flags);
 ssize_t usys_recvmsg(int sockfd, struct msghdr *msg, int flags);
+ssize_t usys_recvmmsg(int sockfd, struct mmsghdr *msgvec, int vlen, int flags,
+                      struct timespec *timeout);
 long usys_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
 long usys_accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen,
                   int flags);

--- a/junction/net/CMakeLists.txt
+++ b/junction/net/CMakeLists.txt
@@ -42,3 +42,11 @@ add_executable(unix_socket_dgram_test
 
 test_bin(unix_socket_stream_test "$<TARGET_FILE:unix_socket_stream_test>")
 test_bin(unix_socket_dgram_test "$<TARGET_FILE:unix_socket_dgram_test>")
+
+add_executable(udp_socket_test
+  udp_socket_test.cc
+)
+target_link_libraries(udp_socket_test
+  "$<LINK_LIBRARY:WHOLE_ARCHIVE,gtest_main>"
+)
+test_bin(udp_socket_test "$<TARGET_FILE:udp_socket_test>")

--- a/junction/net/CMakeLists.txt
+++ b/junction/net/CMakeLists.txt
@@ -2,9 +2,10 @@ message(STATUS "Building junction net")
 
 # Library
 add_library(net
+  caladan_poll.cc
   net.cc
   netlink.cc
-  caladan_poll.cc
+  socket.cc
   unix_socket.cc
 )
 

--- a/junction/net/net.cc
+++ b/junction/net/net.cc
@@ -171,13 +171,15 @@ long usys_getsockopt(int sockfd, int level, int option_name, void *option_value,
     return 0;
   }
   Socket &s = sock_ret.value().get();
-  Status<int> val = s.GetSockOpt(level, option_name);
+  Status<size_t> val = s.GetSockOpt(
+      level, option_name,
+      std::span<std::byte>(reinterpret_cast<std::byte *>(option_value),
+                           option_len ? *option_len : 0));
   if (!val) {
     LOG_ONCE(WARN) << "Unsupported: getsockopt";
-  } else {
-    if (!option_len || *option_len < sizeof(int)) return -EINVAL;
-    *reinterpret_cast<int *>(option_value) = *val;
+    return MakeCError(val);
   }
+  *option_len = *val;
   return 0;
 }
 

--- a/junction/net/net.cc
+++ b/junction/net/net.cc
@@ -198,6 +198,37 @@ ssize_t usys_recvfrom(int sockfd, void *buf, size_t len, int flags,
   return static_cast<ssize_t>(*ret);
 }
 
+Status<size_t> DoRecvMsg(Socket &s, struct msghdr *msg, bool peek,
+                         bool nonblocking) {
+  aux_rx_pkt_data aux;
+  aux.valid = false;
+  const SockAddrPtr p = SockAddrPtr::asConst(
+      reinterpret_cast<const sockaddr *>(msg->msg_name), &msg->msg_namelen);
+  Status<size_t> ret =
+      s.ReadvFrom({msg->msg_iov, msg->msg_iovlen}, p, peek, nonblocking, &aux);
+  if (unlikely(!ret)) return ret;
+  msg->msg_flags = 0;
+
+  if (msg->msg_controllen && aux.valid &&
+      (s.socket_options() & kSockOptRecvTos)) {
+    size_t len = CMSG_SPACE(sizeof(uint8_t));
+    if (msg->msg_controllen < len) {
+      LOG_ONCE(WARN) << "recv msg: control message too short";
+      msg->msg_controllen = 0;
+      msg->msg_flags = MSG_CTRUNC;
+    } else {
+      auto chdr = CMSG_FIRSTHDR(msg);
+      chdr->cmsg_len = len;
+      chdr->cmsg_level = IPPROTO_IP;
+      chdr->cmsg_type = IP_TOS;
+      *reinterpret_cast<uint8_t *>(CMSG_DATA(chdr)) = aux.tos;
+      msg->msg_controllen = len;
+      msg->msg_flags = 0;
+    }
+  }
+  return *ret;
+}
+
 ssize_t usys_recvmsg(int sockfd, struct msghdr *msg, int flags) {
   bool peek = flags & kMsgPeek;
   bool nonblocking = flags & kMsgDontWait;
@@ -206,17 +237,11 @@ ssize_t usys_recvmsg(int sockfd, struct msghdr *msg, int flags) {
     LOG_ONCE(WARN) << "recvmsg ignoring flags" << flags;
     return -EINVAL;
   }
-  if (msg->msg_control || msg->msg_controllen) {
-    LOG_ONCE(WARN) << "recvmsg: ignoring control message";
-    msg->msg_controllen = 0;
-  }
+
   auto sock_ret = FDToSocket(sockfd);
   if (unlikely(!sock_ret)) return MakeCError(sock_ret);
   Socket &s = sock_ret.value().get();
-  const SockAddrPtr p = SockAddrPtr::asConst(
-      reinterpret_cast<const sockaddr *>(msg->msg_name), &msg->msg_namelen);
-  Status<size_t> ret =
-      s.ReadvFrom({msg->msg_iov, msg->msg_iovlen}, p, peek, nonblocking);
+  Status<size_t> ret = DoRecvMsg(s, msg, peek, nonblocking);
   if (unlikely(!ret)) return MakeCError(ret);
   return static_cast<ssize_t>(*ret);
 }
@@ -246,14 +271,8 @@ ssize_t usys_recvmmsg(int sockfd, struct mmsghdr *msgvec, int vlen, int flags,
   for (i = 0; i < vlen; i++) {
     if (timeout && Time::Now() >= end_time) break;
     struct msghdr *msg = &msgvec[i].msg_hdr;
-    if (msg->msg_control || msg->msg_controllen) {
-      LOG_ONCE(WARN) << "recvmmsg: ignoring control message";
-      msg->msg_controllen = 0;
-    }
-    const SockAddrPtr p = SockAddrPtr::asConst(
-        reinterpret_cast<const sockaddr *>(msg->msg_name), &msg->msg_namelen);
     nonblocking |= (i > 0 && wait_for_one);
-    ret = s.ReadvFrom({msg->msg_iov, msg->msg_iovlen}, p, peek, nonblocking);
+    ret = DoRecvMsg(s, msg, peek, nonblocking);
     if (unlikely(!ret)) {
       if (i > 0) return i;
       return MakeCError(ret);
@@ -279,6 +298,30 @@ ssize_t usys_sendto(int sockfd, const void *buf, size_t len, int flags,
   return static_cast<ssize_t>(*ret);
 }
 
+Status<size_t> DoSendMsg(Socket &s, const struct msghdr *msg,
+                         bool nonblocking) {
+  const SockAddrPtr p = SockAddrPtr::asConst(
+      reinterpret_cast<const sockaddr *>(msg->msg_name), &msg->msg_namelen);
+  aux_tx_pkt_data aux;
+  aux.fields_present = 0;
+  if (msg->msg_controllen && msg->msg_control) {
+    struct cmsghdr *cmsg;
+    for (cmsg = CMSG_FIRSTHDR(const_cast<struct msghdr *>(msg)); cmsg != NULL;
+         cmsg = CMSG_NXTHDR(const_cast<struct msghdr *>(msg), cmsg)) {
+      if (cmsg->cmsg_level == IPPROTO_IP && cmsg->cmsg_type == IP_TOS) {
+        aux.ecn = *reinterpret_cast<uint8_t *>(CMSG_DATA(cmsg));
+        aux.has_ecn = true;
+      } else {
+        LOG_ONCE(WARN) << "sendmsg: ignoring control message";
+      }
+    }
+  }
+  Status<size_t> ret =
+      s.WritevTo({msg->msg_iov, msg->msg_iovlen}, p, nonblocking, &aux);
+  if (unlikely(!ret)) return MakeCError(ret);
+  return static_cast<ssize_t>(*ret);
+}
+
 ssize_t usys_sendmsg(int sockfd, const struct msghdr *msg, int flags) {
   bool nonblocking = flags & kMsgDontWait;
   flags &= ~(kMsgNoSignal | kMsgDontWait);
@@ -286,15 +329,10 @@ ssize_t usys_sendmsg(int sockfd, const struct msghdr *msg, int flags) {
     LOG_ONCE(WARN) << "sendmsg ignoring flags " << flags;
     return -EINVAL;
   }
-  if (msg->msg_control || msg->msg_controllen)
-    LOG_ONCE(WARN) << "sendmsg: ignoring control message";
   auto sock_ret = FDToSocket(sockfd);
   if (unlikely(!sock_ret)) return MakeCError(sock_ret);
   Socket &s = sock_ret.value().get();
-  const SockAddrPtr p = SockAddrPtr::asConst(
-      reinterpret_cast<const sockaddr *>(msg->msg_name), &msg->msg_namelen);
-  Status<size_t> ret =
-      s.WritevTo({msg->msg_iov, msg->msg_iovlen}, p, nonblocking);
+  Status<size_t> ret = DoSendMsg(s, msg, nonblocking);
   if (unlikely(!ret)) return MakeCError(ret);
   return static_cast<ssize_t>(*ret);
 }
@@ -314,19 +352,13 @@ ssize_t usys_sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
 
   for (unsigned int i = 0; i < vlen; i++) {
     struct msghdr *msg = &msgvec[i].msg_hdr;
-    if (msg->msg_control || msg->msg_controllen)
-      LOG_ONCE(WARN) << "sendmsg: ignoring control message";
-    const SockAddrPtr p = SockAddrPtr::asConst(
-        reinterpret_cast<const sockaddr *>(msg->msg_name), &msg->msg_namelen);
-    Status<size_t> ret =
-        s.WritevTo({msg->msg_iov, msg->msg_iovlen}, p, nonblocking);
-    if (!ret) {
+    Status<size_t> ret = DoSendMsg(s, msg, nonblocking);
+    if (unlikely(!ret)) {
       if (i > 0) return i;
       return MakeCError(ret);
     }
     msgvec[i].msg_len = *ret;
   }
-
   return vlen;
 }
 

--- a/junction/net/net.cc
+++ b/junction/net/net.cc
@@ -219,6 +219,45 @@ ssize_t usys_recvmsg(int sockfd, struct msghdr *msg, int flags) {
   return static_cast<ssize_t>(*ret);
 }
 
+ssize_t usys_recvmmsg(int sockfd, struct mmsghdr *msgvec, int vlen, int flags,
+                      struct timespec *timeout) {
+  bool peek = flags & kMsgPeek;
+  bool nonblocking = flags & kMsgDontWait;
+  bool wait_for_one = flags & kMsgWaitOne;
+  flags = flags & ~(kMsgNoSignal | kMsgPeek | kMsgDontWait | kMsgWaitOne);
+  if (unlikely(flags != 0)) {
+    LOG_ONCE(WARN) << "recvmmsg ignoring flags" << flags;
+    return -EINVAL;
+  }
+
+  auto sock_ret = FDToSocket(sockfd);
+  if (unlikely(!sock_ret)) return MakeCError(sock_ret);
+  Socket &s = sock_ret.value().get();
+
+  // The timeout is fairly buggy as implemented in Linux (only checks after each
+  // message is received); we do the same here.
+  Time end_time;
+  if (timeout) end_time = Time::Now() + Duration(*timeout);
+  Status<size_t> ret;
+  int i;
+
+  for (i = 0; i < vlen; i++) {
+    struct msghdr *msg = &msgvec[i].msg_hdr;
+    if (msg->msg_control || msg->msg_controllen)
+      LOG_ONCE(WARN) << "recvmmsg: ignoring control message";
+    const SockAddrPtr p = SockAddrPtr::asConst(
+        reinterpret_cast<const sockaddr *>(msg->msg_name), &msg->msg_namelen);
+    nonblocking |= (i > 0 && wait_for_one);
+    ret = s.ReadvFrom({msg->msg_iov, msg->msg_iovlen}, p, peek, nonblocking);
+    if (unlikely(!ret)) break;
+    msgvec[i].msg_len = *ret;
+    if (timeout && Time::Now() >= end_time) break;
+  }
+
+  if (i == 0 && vlen > 0) return MakeCError(ret);
+  return i;
+}
+
 ssize_t usys_sendto(int sockfd, const void *buf, size_t len, int flags,
                     const struct sockaddr *dest_addr, socklen_t addrlen) {
   bool nonblocking = flags & kMsgDontWait;

--- a/junction/net/net.cc
+++ b/junction/net/net.cc
@@ -142,17 +142,22 @@ long usys_connect(int sockfd, const struct sockaddr *addr_in,
   return 0;
 }
 
-// TODO(girfan): Think about how to properly handle this.
-long usys_setsockopt(int sockfd, [[maybe_unused]] int level,
-                     [[maybe_unused]] int option_name,
-                     [[maybe_unused]] const void *option_value,
-                     [[maybe_unused]] socklen_t option_len) {
+long usys_setsockopt(int sockfd, int level, int option_name,
+                     const void *option_value, socklen_t option_len) {
   auto sock_ret = FDToSocket(sockfd);
   if (unlikely(!sock_ret)) return MakeCError(sock_ret);
+  Socket &s = sock_ret.value().get();
   if (level == SOL_IPV6) {
     return -ENOPROTOOPT;
   }
-  LOG_ONCE(WARN) << "Unsupported: setsockopt";
+  Status<void> val = s.SetSockOpt(
+      level, option_name,
+      std::span<const std::byte>(
+          reinterpret_cast<const std::byte *>(option_value), option_len));
+  if (!val) {
+    LOG_ONCE(WARN) << "Unsupported: setsockopt";
+    return MakeCError(val);
+  }
   return 0;
 }
 

--- a/junction/net/net.cc
+++ b/junction/net/net.cc
@@ -206,8 +206,10 @@ ssize_t usys_recvmsg(int sockfd, struct msghdr *msg, int flags) {
     LOG_ONCE(WARN) << "recvmsg ignoring flags" << flags;
     return -EINVAL;
   }
-  if (msg->msg_control || msg->msg_controllen)
+  if (msg->msg_control || msg->msg_controllen) {
     LOG_ONCE(WARN) << "recvmsg: ignoring control message";
+    msg->msg_controllen = 0;
+  }
   auto sock_ret = FDToSocket(sockfd);
   if (unlikely(!sock_ret)) return MakeCError(sock_ret);
   Socket &s = sock_ret.value().get();
@@ -242,19 +244,23 @@ ssize_t usys_recvmmsg(int sockfd, struct mmsghdr *msgvec, int vlen, int flags,
   int i;
 
   for (i = 0; i < vlen; i++) {
+    if (timeout && Time::Now() >= end_time) break;
     struct msghdr *msg = &msgvec[i].msg_hdr;
-    if (msg->msg_control || msg->msg_controllen)
+    if (msg->msg_control || msg->msg_controllen) {
       LOG_ONCE(WARN) << "recvmmsg: ignoring control message";
+      msg->msg_controllen = 0;
+    }
     const SockAddrPtr p = SockAddrPtr::asConst(
         reinterpret_cast<const sockaddr *>(msg->msg_name), &msg->msg_namelen);
     nonblocking |= (i > 0 && wait_for_one);
     ret = s.ReadvFrom({msg->msg_iov, msg->msg_iovlen}, p, peek, nonblocking);
-    if (unlikely(!ret)) break;
+    if (unlikely(!ret)) {
+      if (i > 0) return i;
+      return MakeCError(ret);
+    }
     msgvec[i].msg_len = *ret;
-    if (timeout && Time::Now() >= end_time) break;
   }
 
-  if (i == 0 && vlen > 0) return MakeCError(ret);
   return i;
 }
 

--- a/junction/net/netlink.cc
+++ b/junction/net/netlink.cc
@@ -31,7 +31,8 @@ class NetlinkSocket : public Socket {
   }
 
   Status<size_t> ReadvFrom(std::span<iovec> iovs, SockAddrPtr raddr, bool peek,
-                           bool nonblocking) override {
+                           bool nonblocking,
+                           [[maybe_unused]] aux_rx_pkt_data *aux) override {
     BUG_ON(peek && iovs.size() > 1);
     size_t read_bytes = 0;
     Status<size_t> ret;

--- a/junction/net/socket.cc
+++ b/junction/net/socket.cc
@@ -1,5 +1,7 @@
 #include "junction/net/socket.h"
 
+#include "junction/bindings/log.h"
+
 namespace junction {
 
 Status<size_t> Socket::GetSockOpt(int level, int optname,
@@ -56,16 +58,18 @@ Status<void> IPSocket::SetIPSocketOptions(int optname,
                                           std::span<const std::byte> optval) {
   if (optval.size() < sizeof(int)) return MakeError(EINVAL);
   const int val = *reinterpret_cast<const int *>(optval.data());
-  if (optname == kIPRecvTosOptName) {
+  if (optname == IP_RECVTOS) {
     if (!val)
       remove_socket_option(kSockOptRecvTos);
     else
       add_socket_option(kSockOptRecvTos);
-  } else if (optname == kIPPktInfoOptName) {
+  } else if (optname == IP_PKTINFO) {
     if (!val)
       remove_socket_option(kSockOptPktInfo);
     else
       add_socket_option(kSockOptPktInfo);
+  } else if (optname == IP_MTU_DISCOVER) {
+    LOG_ONCE(WARN) << "Setsockopt: ignoring IP_MTU_DISCOVER directive";
   } else {
     return MakeError(EINVAL);
   }
@@ -76,10 +80,13 @@ Status<size_t> IPSocket::GetIPSocketOptions(int optname,
                                             std::span<std::byte> value) const {
   if (value.size() < sizeof(int)) return MakeError(EINVAL);
   int *optval = reinterpret_cast<int *>(value.data());
-  if (optname == kIPRecvTosOptName) {
+  if (optname == IP_RECVTOS) {
     *optval = socket_options() & kSockOptRecvTos ? 1 : 0;
-  } else if (optname == kIPPktInfoOptName) {
+  } else if (optname == IP_PKTINFO) {
     *optval = socket_options() & kSockOptPktInfo ? 1 : 0;
+  } else if (optname == IP_MTU) {
+    LOG_ONCE(WARN) << "Getsockopt: reporting default (non-path specific) MTU";
+    *optval = udp_get_payload_size();
   } else {
     return MakeError(EINVAL);
   }

--- a/junction/net/socket.cc
+++ b/junction/net/socket.cc
@@ -1,0 +1,89 @@
+#include "junction/net/socket.h"
+
+namespace junction {
+
+Status<size_t> Socket::GetSockOpt(int level, int optname,
+                                  std::span<std::byte> value) const {
+  if (level == IPPROTO_TCP || level == IPPROTO_UDP)
+    return GetSockOptImpl(level, optname, value);
+  if (level == IPPROTO_IP) return GetIPSocketOptions(optname, value);
+  if (level != SOL_SOCKET) return MakeError(EINVAL);
+  switch (optname) {
+    case SO_REUSEPORT:
+      if (value.size() < sizeof(int)) return MakeError(EINVAL);
+      *reinterpret_cast<int *>(value.data()) = reuse_port() ? 1 : 0;
+      return sizeof(int);
+    case SO_RCVTIMEO:
+      if (value.size() < sizeof(timeval)) return MakeError(EINVAL);
+      *reinterpret_cast<timeval *>(value.data()) = read_timeout_.Timeval();
+      return sizeof(timeval);
+    case SO_SNDTIMEO:
+      if (value.size() < sizeof(timeval)) return MakeError(EINVAL);
+      *reinterpret_cast<timeval *>(value.data()) = write_timeout_.Timeval();
+      return sizeof(timeval);
+    default:
+      return GetSockOptImpl(level, optname, value);
+  }
+}
+
+Status<void> Socket::SetSockOpt(int level, int optname,
+                                std::span<const std::byte> value) {
+  if (level == IPPROTO_TCP || level == IPPROTO_UDP)
+    return SetSockOptImpl(level, optname, value);
+  if (level == IPPROTO_IP) return SetIPSocketOptions(optname, value);
+  if (level != SOL_SOCKET) return MakeError(EINVAL);
+  switch (optname) {
+    case SO_REUSEADDR:
+    case SO_REUSEPORT:
+      reuse_port_ = *reinterpret_cast<const int *>(value.data());
+      return {};
+    case SO_RCVTIMEO:
+      if (value.size() < sizeof(timeval)) return MakeError(EINVAL);
+      read_timeout_ =
+          Duration(*reinterpret_cast<const timeval *>(value.data()));
+      return {};
+    case SO_SNDTIMEO:
+      if (value.size() < sizeof(timeval)) return MakeError(EINVAL);
+      write_timeout_ =
+          Duration(*reinterpret_cast<const timeval *>(value.data()));
+      return {};
+    default:
+      return SetSockOptImpl(level, optname, value);
+  }
+}
+
+Status<void> IPSocket::SetIPSocketOptions(int optname,
+                                          std::span<const std::byte> optval) {
+  if (optval.size() < sizeof(int)) return MakeError(EINVAL);
+  const int val = *reinterpret_cast<const int *>(optval.data());
+  if (optname == kIPRecvTosOptName) {
+    if (!val)
+      remove_socket_option(kSockOptRecvTos);
+    else
+      add_socket_option(kSockOptRecvTos);
+  } else if (optname == kIPPktInfoOptName) {
+    if (!val)
+      remove_socket_option(kSockOptPktInfo);
+    else
+      add_socket_option(kSockOptPktInfo);
+  } else {
+    return MakeError(EINVAL);
+  }
+  return {};
+}
+
+Status<size_t> IPSocket::GetIPSocketOptions(int optname,
+                                            std::span<std::byte> value) const {
+  if (value.size() < sizeof(int)) return MakeError(EINVAL);
+  int *optval = reinterpret_cast<int *>(value.data());
+  if (optname == kIPRecvTosOptName) {
+    *optval = socket_options() & kSockOptRecvTos ? 1 : 0;
+  } else if (optname == kIPPktInfoOptName) {
+    *optval = socket_options() & kSockOptPktInfo ? 1 : 0;
+  } else {
+    return MakeError(EINVAL);
+  }
+  return sizeof(int);
+}
+
+}  // namespace junction

--- a/junction/net/socket.h
+++ b/junction/net/socket.h
@@ -56,11 +56,6 @@ struct sockaddr_un {
   char sun_path[108];
 };
 
-// Similarly provide defintions for IP socket options to avoid pulling in
-// Linux headers that conflict with Caladan.
-inline constexpr int kIPRecvTosOptName = 13;  // IP_TOS
-inline constexpr int kIPPktInfoOptName = 8;   // IP_PKTINFO
-
 struct SockAddrPtr {
   explicit SockAddrPtr() : addr(nullptr), addrlen(nullptr) {}
   SockAddrPtr(struct sockaddr *addr, socklen_t *addrlen)

--- a/junction/net/socket.h
+++ b/junction/net/socket.h
@@ -18,6 +18,7 @@ static_assert(kFlagCloseExec == SOCK_CLOEXEC);
 inline constexpr unsigned int kMsgNoSignal = MSG_NOSIGNAL;
 inline constexpr unsigned int kMsgPeek = MSG_PEEK;
 inline constexpr unsigned int kMsgDontWait = MSG_DONTWAIT;
+inline constexpr unsigned int kMsgWaitOne = MSG_WAITFORONE;
 inline constexpr unsigned int kSockTypeMask = 0xf;
 
 enum class UnixSocketAddressType {
@@ -139,13 +140,48 @@ class Socket : public File {
     return MakeError(ENOTCONN);
   }
 
-  virtual Status<int> GetSockOpt(int level, int optname) const {
-    return MakeError(EINVAL);
+  Status<size_t> GetSockOpt(int level, int optname,
+                            std::span<std::byte> value) const {
+    if (level != SOL_SOCKET) return MakeError(EINVAL);
+    switch (optname) {
+      case SO_REUSEPORT:
+        if (value.size() < sizeof(int)) return MakeError(EINVAL);
+        *reinterpret_cast<int *>(value.data()) = reuse_port() ? 1 : 0;
+        return sizeof(int);
+      case SO_RCVTIMEO:
+        if (value.size() < sizeof(timeval)) return MakeError(EINVAL);
+        *reinterpret_cast<timeval *>(value.data()) = read_timeout_.Timeval();
+        return sizeof(timeval);
+      case SO_SNDTIMEO:
+        if (value.size() < sizeof(timeval)) return MakeError(EINVAL);
+        *reinterpret_cast<timeval *>(value.data()) = write_timeout_.Timeval();
+        return sizeof(timeval);
+      default:
+        return GetSockOptImpl(level, optname, value);
+    }
   }
 
-  virtual Status<void> SetSockOpt(int level, int optname,
-                                  std::span<const std::byte> value) {
-    return MakeError(EINVAL);
+  Status<void> SetSockOpt(int level, int optname,
+                          std::span<const std::byte> value) {
+    if (level != SOL_SOCKET) return MakeError(EINVAL);
+    switch (optname) {
+      case SO_REUSEADDR:
+      case SO_REUSEPORT:
+        reuse_port_ = *reinterpret_cast<const int *>(value.data());
+        return {};
+      case SO_RCVTIMEO:
+        if (value.size() < sizeof(timeval)) return MakeError(EINVAL);
+        read_timeout_ =
+            Duration(*reinterpret_cast<const timeval *>(value.data()));
+        return {};
+      case SO_SNDTIMEO:
+        if (value.size() < sizeof(timeval)) return MakeError(EINVAL);
+        write_timeout_ =
+            Duration(*reinterpret_cast<const timeval *>(value.data()));
+        return {};
+      default:
+        return SetSockOptImpl(level, optname, value);
+    }
   }
 
   Status<size_t> Read(std::span<std::byte> buf, off_t *off) override {
@@ -166,18 +202,38 @@ class Socket : public File {
     return "socket:";
   }
 
+ protected:
+  [[nodiscard]] Duration read_timeout() const { return read_timeout_; }
+  [[nodiscard]] Duration write_timeout() const { return write_timeout_; }
+  [[nodiscard]] bool reuse_port() const { return reuse_port_; }
+
+  virtual Status<void> SetSockOptImpl(int level, int optname,
+                                      std::span<const std::byte> optval) {
+    return MakeError(EINVAL);
+  }
+  virtual Status<size_t> GetSockOptImpl(int level, int optname,
+                                        std::span<std::byte> value) const {
+    return MakeError(EINVAL);
+  }
+
  private:
   friend class cereal::access;
 
   template <class Archive>
   void save(Archive &ar) const {
-    ar(cereal::base_class<File>(this));
+    ar(reuse_port_, read_timeout_, write_timeout_,
+       cereal::base_class<File>(this));
   }
 
   template <class Archive>
   void load(Archive &ar) {
-    ar(cereal::base_class<File>(this));
+    ar(reuse_port_, read_timeout_, write_timeout_,
+       cereal::base_class<File>(this));
   }
+
+  bool reuse_port_{false};
+  Duration read_timeout_{0};
+  Duration write_timeout_{0};
 };
 
 }  // namespace junction

--- a/junction/net/socket.h
+++ b/junction/net/socket.h
@@ -143,6 +143,11 @@ class Socket : public File {
     return MakeError(EINVAL);
   }
 
+  virtual Status<void> SetSockOpt(int level, int optname,
+                                  std::span<const std::byte> value) {
+    return MakeError(EINVAL);
+  }
+
   Status<size_t> Read(std::span<std::byte> buf, off_t *off) override {
     return ReadFrom(buf, SockAddrPtr{});
   }

--- a/junction/net/socket.h
+++ b/junction/net/socket.h
@@ -157,7 +157,9 @@ class Socket : public File {
     return {};
   }
 
-  [[nodiscard]] std::string get_filename() const override { return "socket:"; }
+  [[nodiscard]] std::string get_filename(const FSRoot &fs) const override {
+    return "socket:";
+  }
 
  private:
   friend class cereal::access;

--- a/junction/net/socket.h
+++ b/junction/net/socket.h
@@ -21,6 +21,10 @@ inline constexpr unsigned int kMsgDontWait = MSG_DONTWAIT;
 inline constexpr unsigned int kMsgWaitOne = MSG_WAITFORONE;
 inline constexpr unsigned int kSockTypeMask = 0xf;
 
+// Bits defined by Junction to track requested socket options.
+inline constexpr size_t kSockOptPktInfo = BIT(0);
+inline constexpr size_t kSockOptRecvTos = BIT(1);
+
 enum class UnixSocketAddressType {
   Unnamed = 0,  // No name assigned.
   Pathname,     // Sockets using a path in the file system
@@ -51,6 +55,11 @@ struct sockaddr_un {
   sa_family_t sun_family;
   char sun_path[108];
 };
+
+// Similarly provide defintions for IP socket options to avoid pulling in
+// Linux headers that conflict with Caladan.
+inline constexpr int kIPRecvTosOptName = 13;  // IP_TOS
+inline constexpr int kIPPktInfoOptName = 8;   // IP_PKTINFO
 
 struct SockAddrPtr {
   explicit SockAddrPtr() : addr(nullptr), addrlen(nullptr) {}
@@ -111,8 +120,8 @@ class Socket : public File {
     return MakeError(ENOTCONN);
   }
   virtual Status<size_t> ReadvFrom(std::span<iovec> iov, SockAddrPtr raddr,
-                                   bool peek = false,
-                                   bool nonblocking = false) {
+                                   bool peek = false, bool nonblocking = false,
+                                   aux_rx_pkt_data *aux = nullptr) {
     return MakeError(ENOTCONN);
   }
   virtual Status<size_t> WriteTo(std::span<const std::byte> buf,
@@ -123,7 +132,8 @@ class Socket : public File {
 
   virtual Status<size_t> WritevTo(std::span<const iovec> iov,
                                   const SockAddrPtr raddr,
-                                  bool nonblocking = false) {
+                                  bool nonblocking = false,
+                                  aux_tx_pkt_data *aux = nullptr) {
     return MakeError(ENOTCONN);
   }
 
@@ -141,48 +151,10 @@ class Socket : public File {
   }
 
   Status<size_t> GetSockOpt(int level, int optname,
-                            std::span<std::byte> value) const {
-    if (level != SOL_SOCKET) return MakeError(EINVAL);
-    switch (optname) {
-      case SO_REUSEPORT:
-        if (value.size() < sizeof(int)) return MakeError(EINVAL);
-        *reinterpret_cast<int *>(value.data()) = reuse_port() ? 1 : 0;
-        return sizeof(int);
-      case SO_RCVTIMEO:
-        if (value.size() < sizeof(timeval)) return MakeError(EINVAL);
-        *reinterpret_cast<timeval *>(value.data()) = read_timeout_.Timeval();
-        return sizeof(timeval);
-      case SO_SNDTIMEO:
-        if (value.size() < sizeof(timeval)) return MakeError(EINVAL);
-        *reinterpret_cast<timeval *>(value.data()) = write_timeout_.Timeval();
-        return sizeof(timeval);
-      default:
-        return GetSockOptImpl(level, optname, value);
-    }
-  }
+                            std::span<std::byte> value) const;
 
   Status<void> SetSockOpt(int level, int optname,
-                          std::span<const std::byte> value) {
-    if (level != SOL_SOCKET) return MakeError(EINVAL);
-    switch (optname) {
-      case SO_REUSEADDR:
-      case SO_REUSEPORT:
-        reuse_port_ = *reinterpret_cast<const int *>(value.data());
-        return {};
-      case SO_RCVTIMEO:
-        if (value.size() < sizeof(timeval)) return MakeError(EINVAL);
-        read_timeout_ =
-            Duration(*reinterpret_cast<const timeval *>(value.data()));
-        return {};
-      case SO_SNDTIMEO:
-        if (value.size() < sizeof(timeval)) return MakeError(EINVAL);
-        write_timeout_ =
-            Duration(*reinterpret_cast<const timeval *>(value.data()));
-        return {};
-      default:
-        return SetSockOptImpl(level, optname, value);
-    }
-  }
+                          std::span<const std::byte> value);
 
   Status<size_t> Read(std::span<std::byte> buf, off_t *off) override {
     return ReadFrom(buf, SockAddrPtr{});
@@ -202,6 +174,8 @@ class Socket : public File {
     return "socket:";
   }
 
+  [[nodiscard]] size_t socket_options() const { return socket_options_; }
+
  protected:
   [[nodiscard]] Duration read_timeout() const { return read_timeout_; }
   [[nodiscard]] Duration write_timeout() const { return write_timeout_; }
@@ -211,29 +185,56 @@ class Socket : public File {
                                       std::span<const std::byte> optval) {
     return MakeError(EINVAL);
   }
+
   virtual Status<size_t> GetSockOptImpl(int level, int optname,
                                         std::span<std::byte> value) const {
     return MakeError(EINVAL);
   }
+
+  virtual Status<void> SetIPSocketOptions(int optname,
+                                          std::span<const std::byte> optval) {
+    return MakeError(EINVAL);
+  }
+
+  virtual Status<size_t> GetIPSocketOptions(int optname,
+                                            std::span<std::byte> value) const {
+    return MakeError(EINVAL);
+  }
+
+  void add_socket_option(size_t option) { socket_options_ |= option; }
+
+  void remove_socket_option(size_t option) { socket_options_ &= ~option; }
 
  private:
   friend class cereal::access;
 
   template <class Archive>
   void save(Archive &ar) const {
-    ar(reuse_port_, read_timeout_, write_timeout_,
+    ar(reuse_port_, read_timeout_, write_timeout_, socket_options_,
        cereal::base_class<File>(this));
   }
 
   template <class Archive>
   void load(Archive &ar) {
-    ar(reuse_port_, read_timeout_, write_timeout_,
+    ar(reuse_port_, read_timeout_, write_timeout_, socket_options_,
        cereal::base_class<File>(this));
   }
 
   bool reuse_port_{false};
   Duration read_timeout_{0};
   Duration write_timeout_{0};
+  size_t socket_options_{0};
+};
+
+class IPSocket : public Socket {
+  using Socket::Socket;
+
+ protected:
+  Status<void> SetIPSocketOptions(int optname,
+                                  std::span<const std::byte> optval) override;
+
+  Status<size_t> GetIPSocketOptions(int optname,
+                                    std::span<std::byte> value) const override;
 };
 
 }  // namespace junction

--- a/junction/net/tcp_socket.h
+++ b/junction/net/tcp_socket.h
@@ -16,12 +16,12 @@ extern "C" {
 
 namespace junction {
 
-class TCPSocket : public Socket {
+class TCPSocket : public IPSocket {
  public:
   TCPSocket(int flags = 0) noexcept
-      : Socket(flags), state_(SocketState::kSockUnbound) {}
+      : IPSocket(flags), state_(SocketState::kSockUnbound) {}
   TCPSocket(rt::TCPConn conn, int flags = 0) noexcept
-      : Socket(flags),
+      : IPSocket(flags),
         state_(SocketState::kSockConnected),
         v_(std::move(conn)) {}
 
@@ -173,7 +173,8 @@ class TCPSocket : public Socket {
   }
 
   Status<size_t> WritevTo(std::span<const iovec> iov, const SockAddrPtr raddr,
-                          bool nonblocking) override {
+                          bool nonblocking,
+                          [[maybe_unused]] aux_tx_pkt_data *aux) override {
     if (unlikely(state_ != SocketState::kSockConnected))
       return MakeError(EINVAL);
     if (raddr) return MakeError(EISCONN);
@@ -190,7 +191,8 @@ class TCPSocket : public Socket {
   }
 
   Status<size_t> ReadvFrom(std::span<iovec> iov, SockAddrPtr raddr, bool peek,
-                           bool nonblocking) override {
+                           bool nonblocking,
+                           [[maybe_unused]] aux_rx_pkt_data *aux) override {
     if (unlikely(state_ != SocketState::kSockConnected))
       return MakeError(EINVAL);
     if (raddr) raddr.FromNetAddr(TcpConn().RemoteAddr());
@@ -288,7 +290,7 @@ class TCPSocket : public Socket {
 
   template <class Archive>
   void save(Archive &ar) const {
-    ar(cereal::base_class<Socket>(this), state_);
+    ar(cereal::base_class<IPSocket>(this), state_);
 
     switch (state_) {
       case SocketState::kSockBound:
@@ -307,7 +309,7 @@ class TCPSocket : public Socket {
 
   template <class Archive>
   void load(Archive &ar) {
-    ar(cereal::base_class<Socket>(this), state_);
+    ar(cereal::base_class<IPSocket>(this), state_);
 
     if (state_ == SocketState::kSockUnbound) return;
     if (state_ == SocketState::kSockBound) {

--- a/junction/net/tcp_socket.h
+++ b/junction/net/tcp_socket.h
@@ -31,7 +31,7 @@ class TCPSocket : public Socket {
     if (unlikely(state_ != SocketState::kSockUnbound)) return MakeError(EINVAL);
     Status<netaddr> na = addr.ToNetAddr();
     if (unlikely(!na)) return MakeError(na);
-    Status<rt::BindToken> ret = rt::BindToken::AllocateTCP(*na, reuse_port_);
+    Status<rt::BindToken> ret = rt::BindToken::AllocateTCP(*na, reuse_port());
     if (unlikely(!ret)) return MakeError(ret);
     v_ = std::move(*ret);
     state_ = SocketState::kSockBound;
@@ -150,6 +150,7 @@ class TCPSocket : public Socket {
                        [[maybe_unused]] off_t *off = nullptr) override {
     if (unlikely(state_ != SocketState::kSockConnected))
       return MakeError(EINVAL);
+    rt::RuntimeWaitqTimeout timeout(write_timeout());
     return TcpConn().Write(buf);
   }
 
@@ -158,6 +159,7 @@ class TCPSocket : public Socket {
     if (unlikely(state_ != SocketState::kSockConnected))
       return MakeError(EINVAL);
     if (raddr) raddr.FromNetAddr(TcpConn().RemoteAddr());
+    rt::RuntimeWaitqTimeout timeout(read_timeout());
     return TcpConn().Read(buf, peek, nonblocking);
   }
 
@@ -166,6 +168,7 @@ class TCPSocket : public Socket {
     if (unlikely(state_ != SocketState::kSockConnected))
       return MakeError(EINVAL);
     if (raddr) return MakeError(EISCONN);
+    rt::RuntimeWaitqTimeout timeout(write_timeout());
     return TcpConn().Write(buf, nonblocking);
   }
 
@@ -174,6 +177,7 @@ class TCPSocket : public Socket {
     if (unlikely(state_ != SocketState::kSockConnected))
       return MakeError(EINVAL);
     if (raddr) return MakeError(EISCONN);
+    rt::RuntimeWaitqTimeout timeout(write_timeout());
     return TcpConn().Writev(iov, nonblocking);
   }
 
@@ -181,6 +185,7 @@ class TCPSocket : public Socket {
                         [[maybe_unused]] off_t *off = nullptr) override {
     if (unlikely(state_ != SocketState::kSockConnected))
       return MakeError(EINVAL);
+    rt::RuntimeWaitqTimeout timeout(write_timeout());
     return TcpConn().Writev(iov);
   }
 
@@ -189,6 +194,7 @@ class TCPSocket : public Socket {
     if (unlikely(state_ != SocketState::kSockConnected))
       return MakeError(EINVAL);
     if (raddr) raddr.FromNetAddr(TcpConn().RemoteAddr());
+    rt::RuntimeWaitqTimeout timeout(read_timeout());
     return TcpConn().Readv(iov, peek, nonblocking);
   }
 
@@ -196,43 +202,40 @@ class TCPSocket : public Socket {
                        [[maybe_unused]] off_t *off) override {
     if (unlikely(state_ != SocketState::kSockConnected))
       return MakeError(EINVAL);
+    rt::RuntimeWaitqTimeout timeout(read_timeout());
     return TcpConn().Readv(iov);
   }
 
-  Status<int> GetSockOpt(int level, int optname) const override {
+ protected:
+  Status<size_t> GetSockOptImpl(int level, int optname,
+                                std::span<std::byte> value) const override {
     if (level != SOL_SOCKET) return MakeError(EINVAL);
+    int ret;
+    Status<void> rret;
     switch (optname) {
       case SO_ACCEPTCONN:
-        return state_ == SocketState::kSockListening ? 1 : 0;
+        ret = state_ == SocketState::kSockListening ? 1 : 0;
+        break;
       case SO_DOMAIN:
-        return AF_INET;
+        ret = AF_INET;
+        break;
       case SO_PROTOCOL:
-        return IPPROTO_TCP;
+        ret = IPPROTO_TCP;
+        break;
       case SO_TYPE:
-        return SOCK_STREAM;
+        ret = SOCK_STREAM;
+        break;
       case SO_ERROR:
-        if (state_ == SocketState::kSockConnected) {
-          Status<void> ret = TcpConn().GetStatus();
-          return ret ? 0 : ret.error().code();
-        }
-        /* fallthrough */
+        if (state_ != SocketState::kSockConnected) return MakeError(EINVAL);
+        rret = TcpConn().GetStatus();
+        ret = rret ? 0 : rret.error().code();
+        break;
       default:
         return MakeError(EINVAL);
     }
-  }
-
-  Status<void> SetSockOpt(int level, int optname,
-                          std::span<const std::byte> optval) override {
-    if (level != SOL_SOCKET) return MakeError(EINVAL);
-    switch (optname) {
-      case SO_REUSEADDR:
-      case SO_REUSEPORT:
-        if (state_ != SocketState::kSockUnbound) return MakeError(EINVAL);
-        reuse_port_ = *reinterpret_cast<const int *>(optval.data());
-        return {};
-      default:
-        return MakeError(EINVAL);
-    }
+    if (value.size() < sizeof(int)) return MakeError(EINVAL);
+    *reinterpret_cast<int *>(value.data()) = ret;
+    return sizeof(int);
   }
 
  private:
@@ -289,7 +292,7 @@ class TCPSocket : public Socket {
 
     switch (state_) {
       case SocketState::kSockBound:
-        ar(BindToken().LocalAddr(), reuse_port_);
+        ar(BindToken().LocalAddr());
         break;
       case SocketState::kSockConnected:
         ar(TcpConn().LocalAddr(), TcpConn().RemoteAddr());
@@ -309,8 +312,9 @@ class TCPSocket : public Socket {
     if (state_ == SocketState::kSockUnbound) return;
     if (state_ == SocketState::kSockBound) {
       netaddr addr;
-      ar(addr, reuse_port_);
-      Status<rt::BindToken> ret = rt::BindToken::AllocateTCP(addr, reuse_port_);
+      ar(addr, reuse_port());
+      Status<rt::BindToken> ret =
+          rt::BindToken::AllocateTCP(addr, reuse_port());
       BUG_ON(!ret);
       v_ = std::move(*ret);
       return;
@@ -358,7 +362,6 @@ class TCPSocket : public Socket {
 
   SocketState state_;
   int backlog_;
-  bool reuse_port_{false};
   std::atomic_bool is_shut_{false};
   std::variant<rt::TCPConn, rt::TCPQueue, rt::BindToken> v_;
 };

--- a/junction/net/tcp_socket.h
+++ b/junction/net/tcp_socket.h
@@ -25,20 +25,28 @@ class TCPSocket : public Socket {
         state_(SocketState::kSockConnected),
         v_(std::move(conn)) {}
 
-  ~TCPSocket() override = default;
+  ~TCPSocket() = default;
 
   Status<void> Bind(const SockAddrPtr addr) override {
-    // TODO(jsf): this should in theory reserve a port in the socket table
     if (unlikely(state_ != SocketState::kSockUnbound)) return MakeError(EINVAL);
     Status<netaddr> na = addr.ToNetAddr();
     if (unlikely(!na)) return MakeError(na);
-    addr_ = *na;
+    Status<rt::BindToken> ret = rt::BindToken::AllocateTCP(*na, reuse_port_);
+    if (unlikely(!ret)) return MakeError(ret);
+    v_ = std::move(*ret);
     state_ = SocketState::kSockBound;
     return {};
   }
 
   Status<void> Listen(int backlog) override {
-    Status<rt::TCPQueue> ret = rt::TCPQueue::Listen(addr_, backlog);
+    Status<rt::TCPQueue> ret;
+    if (state_ == SocketState::kSockBound) {
+      ret = BindToken().ListenTCP(backlog);
+    } else if (state_ == SocketState::kSockUnbound) {
+      ret = rt::TCPQueue::Listen({}, backlog);
+    } else {
+      return MakeError(EINVAL);
+    }
     if (unlikely(!ret)) return MakeError(ret);
     if (is_nonblocking()) ret->SetNonBlocking(true);
     v_ = std::move(*ret);
@@ -60,10 +68,14 @@ class TCPSocket : public Socket {
     Status<netaddr> na = addr.ToNetAddr();
     if (unlikely(!na)) return MakeError(na);
     Status<rt::TCPConn> ret;
-    if (is_nonblocking())
-      ret = rt::TCPConn::DialNonBlocking(addr_, *na);
-    else
-      ret = rt::TCPConn::Dial(addr_, *na);
+    if (state_ == SocketState::kSockBound) {
+      ret = BindToken().DialTCP(*na, is_nonblocking());
+    } else if (is_nonblocking()) {
+      ret = rt::TCPConn::DialNonBlocking({}, *na);
+    } else {
+      ret = rt::TCPConn::Dial({}, *na);
+    }
+
     if (unlikely(!ret)) return MakeError(ret);
     v_ = std::move(*ret);
     state_ = SocketState::kSockConnected;
@@ -113,7 +125,7 @@ class TCPSocket : public Socket {
     switch (state_) {
       case SocketState::kSockUnbound:
       case SocketState::kSockBound:
-        ptr.FromNetAddr(addr_);
+        ptr.FromNetAddr(BindToken().LocalAddr());
         break;
       case SocketState::kSockConnected:
         ptr.FromNetAddr(TcpConn().LocalAddr());
@@ -209,6 +221,20 @@ class TCPSocket : public Socket {
     }
   }
 
+  Status<void> SetSockOpt(int level, int optname,
+                          std::span<const std::byte> optval) override {
+    if (level != SOL_SOCKET) return MakeError(EINVAL);
+    switch (optname) {
+      case SO_REUSEADDR:
+      case SO_REUSEPORT:
+        if (state_ != SocketState::kSockUnbound) return MakeError(EINVAL);
+        reuse_port_ = *reinterpret_cast<const int *>(optval.data());
+        return {};
+      default:
+        return MakeError(EINVAL);
+    }
+  }
+
  private:
   void SetupPollSource() override {
     PollSource &s = get_poll_source();
@@ -230,13 +256,29 @@ class TCPSocket : public Socket {
       TcpConn().SetNonBlocking(nonblocking);
   }
 
-  [[nodiscard]] rt::TCPConn &TcpConn() { return std::get<rt::TCPConn>(v_); }
-  [[nodiscard]] rt::TCPQueue &TcpQueue() { return std::get<rt::TCPQueue>(v_); }
+  [[nodiscard]] rt::TCPConn &TcpConn() {
+    assert(state_ == SocketState::kSockConnected);
+    return std::get<rt::TCPConn>(v_);
+  }
+  [[nodiscard]] rt::TCPQueue &TcpQueue() {
+    assert(state_ == SocketState::kSockListening);
+    return std::get<rt::TCPQueue>(v_);
+  }
   [[nodiscard]] const rt::TCPConn &TcpConn() const {
+    assert(state_ == SocketState::kSockConnected);
     return std::get<rt::TCPConn>(v_);
   }
   [[nodiscard]] const rt::TCPQueue &TcpQueue() const {
+    assert(state_ == SocketState::kSockListening);
     return std::get<rt::TCPQueue>(v_);
+  }
+  [[nodiscard]] rt::BindToken &BindToken() {
+    assert(state_ == SocketState::kSockBound);
+    return std::get<rt::BindToken>(v_);
+  }
+  [[nodiscard]] const rt::BindToken &BindToken() const {
+    assert(state_ == SocketState::kSockBound);
+    return std::get<rt::BindToken>(v_);
   }
 
   friend class cereal::access;
@@ -247,7 +289,7 @@ class TCPSocket : public Socket {
 
     switch (state_) {
       case SocketState::kSockBound:
-        ar(addr_);
+        ar(BindToken().LocalAddr(), reuse_port_);
         break;
       case SocketState::kSockConnected:
         ar(TcpConn().LocalAddr(), TcpConn().RemoteAddr());
@@ -266,7 +308,11 @@ class TCPSocket : public Socket {
 
     if (state_ == SocketState::kSockUnbound) return;
     if (state_ == SocketState::kSockBound) {
-      ar(addr_);
+      netaddr addr;
+      ar(addr, reuse_port_);
+      Status<rt::BindToken> ret = rt::BindToken::AllocateTCP(addr, reuse_port_);
+      BUG_ON(!ret);
+      v_ = std::move(*ret);
       return;
     }
 
@@ -292,13 +338,14 @@ class TCPSocket : public Socket {
       v_ = std::move(*c);
     } else {
       assert(state_ == SocketState::kSockListening);
-      ar(addr_, is_shut_, backlog_);
-      Status<rt::TCPQueue> q = rt::TCPQueue::Listen(addr_, backlog_);
+      netaddr addr;
+      ar(addr, is_shut_, backlog_);
+      Status<rt::TCPQueue> q = rt::TCPQueue::Listen(addr, backlog_);
       if (unlikely(!q)) {
         char str[IP_ADDR_STR_LEN];
-        char *ip = ip_addr_to_str(addr_.ip, str);
+        char *ip = ip_addr_to_str(addr.ip, str);
         LOG(ERR) << "failed to restore TCP listen socket @ " << ip << ":"
-                 << addr_.port;
+                 << addr.port;
         BUG();
       }
       if (is_nonblocking()) q->SetNonBlocking(true);
@@ -310,10 +357,10 @@ class TCPSocket : public Socket {
   }
 
   SocketState state_;
-  netaddr addr_{0, 0};
   int backlog_;
+  bool reuse_port_{false};
   std::atomic_bool is_shut_{false};
-  std::variant<rt::TCPConn, rt::TCPQueue> v_;
+  std::variant<rt::TCPConn, rt::TCPQueue, rt::BindToken> v_;
 };
 
 }  // namespace junction

--- a/junction/net/udp_socket.h
+++ b/junction/net/udp_socket.h
@@ -23,7 +23,7 @@ class UDPSocket : public Socket {
     if (unlikely(conn_.is_valid())) return MakeError(EINVAL);
     Status<netaddr> na = addr.ToNetAddr();
     if (unlikely(!na)) return MakeError(na);
-    Status<rt::BindToken> ret = rt::BindToken::AllocateUDP(*na, reuse_port_);
+    Status<rt::BindToken> ret = rt::BindToken::AllocateUDP(*na, reuse_port());
     if (unlikely(!ret)) return MakeError(ret);
     bind_token_ = std::move(*ret);
     return {};
@@ -48,18 +48,21 @@ class UDPSocket : public Socket {
   Status<size_t> Read(std::span<std::byte> buf,
                       [[maybe_unused]] off_t *off) override {
     if (unlikely(!conn_.is_valid())) return MakeError(EINVAL);
+    rt::RuntimeWaitqTimeout timeout(read_timeout());
     return conn_.Read(buf);
   }
 
   Status<size_t> Write(std::span<const std::byte> buf,
                        [[maybe_unused]] off_t *off) override {
     if (unlikely(!conn_.is_valid())) return MakeError(EDESTADDRREQ);
+    rt::RuntimeWaitqTimeout timeout(write_timeout());
     return conn_.Write(buf);
   }
 
   Status<size_t> Writev(std::span<const iovec> iov,
                         [[maybe_unused]] off_t *off) override {
     if (unlikely(!conn_.is_valid())) return MakeError(EDESTADDRREQ);
+    rt::RuntimeWaitqTimeout timeout(write_timeout());
     return conn_.WritevTo(iov, nullptr, is_nonblocking());
   }
 
@@ -69,6 +72,7 @@ class UDPSocket : public Socket {
       if (Status<void> ret = TrySetupConn(false); !ret) return MakeError(ret);
     }
     netaddr ra;
+    rt::RuntimeWaitqTimeout timeout(read_timeout());
     Status<size_t> ret =
         conn_.ReadFrom(buf, raddr ? &ra : nullptr, peek, nonblocking);
     if (unlikely(!ret)) return ret;
@@ -82,6 +86,7 @@ class UDPSocket : public Socket {
       if (Status<void> ret = TrySetupConn(false); !ret) return MakeError(ret);
     }
     netaddr ra;
+    rt::RuntimeWaitqTimeout timeout(read_timeout());
     Status<size_t> ret =
         conn_.ReadvFrom(iov, raddr ? &ra : nullptr, peek, nonblocking);
     if (unlikely(!ret)) return ret;
@@ -94,6 +99,7 @@ class UDPSocket : public Socket {
     if (!conn_.is_valid()) {
       if (Status<void> ret = TrySetupConn(true); !ret) return MakeError(ret);
     }
+    rt::RuntimeWaitqTimeout timeout(write_timeout());
     if (raddr) {
       Status<netaddr> ra = raddr.ToNetAddr();
       if (unlikely(!ra)) return MakeError(ra);
@@ -107,7 +113,7 @@ class UDPSocket : public Socket {
     if (!conn_.is_valid()) {
       if (Status<void> ret = TrySetupConn(true); !ret) return MakeError(ret);
     }
-
+    rt::RuntimeWaitqTimeout timeout(write_timeout());
     if (raddr) {
       Status<netaddr> ra = raddr.ToNetAddr();
       if (unlikely(!ra)) return MakeError(ra);
@@ -145,33 +151,27 @@ class UDPSocket : public Socket {
     return {};
   }
 
-  Status<int> GetSockOpt(int level, int optname) const override {
+ protected:
+  Status<size_t> GetSockOptImpl(int level, int optname,
+                                std::span<std::byte> value) const override {
     if (level != SOL_SOCKET) return MakeError(EINVAL);
+    int ret;
     switch (optname) {
       case SO_DOMAIN:
-        return AF_INET;
+        ret = AF_INET;
+        break;
       case SO_PROTOCOL:
-        return IPPROTO_UDP;
+        ret = IPPROTO_UDP;
+        break;
       case SO_TYPE:
-        return SOCK_DGRAM;
+        ret = SOCK_DGRAM;
+        break;
       default:
         return MakeError(EINVAL);
     }
-  }
-
-  Status<void> SetSockOpt(int level, int optname,
-                          std::span<const std::byte> optval) override {
-    if (level != SOL_SOCKET) return MakeError(EINVAL);
-    switch (optname) {
-      case SO_REUSEADDR:
-      case SO_REUSEPORT:
-        if (conn_.is_valid() || bind_token_.is_valid())
-          return MakeError(EINVAL);
-        reuse_port_ = *reinterpret_cast<const int *>(optval.data());
-        return {};
-      default:
-        return MakeError(EINVAL);
-    }
+    if (value.size() < sizeof(int)) return MakeError(EINVAL);
+    *reinterpret_cast<int *>(value.data()) = ret;
+    return sizeof(int);
   }
 
  private:
@@ -221,7 +221,7 @@ class UDPSocket : public Socket {
   template <class Archive>
   void save(Archive &ar) const {
     ar(cereal::base_class<Socket>(this), conn_.is_valid(),
-       bind_token_.is_valid(), reuse_port_);
+       bind_token_.is_valid());
     if (conn_.is_valid())
       ar(conn_.LocalAddr(), conn_.RemoteAddr(), is_shut_);
     else if (bind_token_.is_valid())
@@ -231,8 +231,7 @@ class UDPSocket : public Socket {
   template <class Archive>
   void load(Archive &ar) {
     bool conn_is_valid, bind_token_is_valid;
-    ar(cereal::base_class<Socket>(this), conn_is_valid, bind_token_is_valid,
-       reuse_port_);
+    ar(cereal::base_class<Socket>(this), conn_is_valid, bind_token_is_valid);
 
     netaddr laddr, raddr;
 
@@ -240,7 +239,7 @@ class UDPSocket : public Socket {
       assert(!conn_.is_valid());
       ar(laddr);
       Status<rt::BindToken> ret =
-          rt::BindToken::AllocateUDP(laddr, reuse_port_);
+          rt::BindToken::AllocateUDP(laddr, reuse_port());
       if (unlikely(!ret)) {
         LOG(ERR) << "failed to restore UDP bind token @ " << laddr.ip << ":"
                  << laddr.port;
@@ -282,7 +281,6 @@ class UDPSocket : public Socket {
   rt::UDPConn conn_;
   rt::BindToken bind_token_;
   std::atomic_bool is_shut_{false};
-  bool reuse_port_{false};
 };
 
 }  // namespace junction

--- a/junction/net/udp_socket.h
+++ b/junction/net/udp_socket.h
@@ -23,28 +23,25 @@ class UDPSocket : public Socket {
     if (unlikely(conn_.is_valid())) return MakeError(EINVAL);
     Status<netaddr> na = addr.ToNetAddr();
     if (unlikely(!na)) return MakeError(na);
-    Status<rt::UDPConn> ret = rt::UDPConn::Listen(*na);
+    Status<rt::BindToken> ret = rt::BindToken::AllocateUDP(*na, reuse_port_);
     if (unlikely(!ret)) return MakeError(ret);
-    conn_ = std::move(*ret);
-    if (is_nonblocking()) conn_.SetNonBlocking(true);
-    if (IsPollSourceSetup()) SetupPollSource();
+    bind_token_ = std::move(*ret);
     return {};
   }
 
   Status<void> Connect(const SockAddrPtr addr) override {
-    netaddr laddr;
-    if (conn_.is_valid()) {
-      netaddr remote = conn_.RemoteAddr();
-      if (unlikely(remote.ip || remote.port)) return MakeError(EINVAL);
-      laddr = conn_.LocalAddr();
-    } else {
-      laddr = {0, 0};
-    }
+    if (unlikely(conn_.is_valid())) return MakeError(EISCONN);
     Status<netaddr> raddr = addr.ToNetAddr();
     if (unlikely(!raddr)) return MakeError(raddr);
-    Status<rt::UDPConn> ret = rt::UDPConn::Dial(laddr, *raddr);
+
+    Status<rt::UDPConn> ret;
+    if (bind_token_.is_valid())
+      ret = bind_token_.DialUDP(*raddr);
+    else
+      ret = rt::UDPConn::Dial({}, *raddr);
+
     if (unlikely(!ret)) return MakeError(ret);
-    ReplaceConn(std::move(*ret));
+    InstallConn(std::move(*ret));
     return {};
   }
 
@@ -68,7 +65,9 @@ class UDPSocket : public Socket {
 
   Status<size_t> ReadFrom(std::span<std::byte> buf, SockAddrPtr raddr,
                           bool peek, bool nonblocking) override {
-    if (unlikely(!conn_.is_valid())) return MakeError(EINVAL);
+    if (unlikely(!conn_.is_valid())) {
+      if (Status<void> ret = TrySetupConn(false); !ret) return MakeError(ret);
+    }
     netaddr ra;
     Status<size_t> ret =
         conn_.ReadFrom(buf, raddr ? &ra : nullptr, peek, nonblocking);
@@ -79,7 +78,9 @@ class UDPSocket : public Socket {
 
   Status<size_t> ReadvFrom(std::span<iovec> iov, SockAddrPtr raddr, bool peek,
                            bool nonblocking) override {
-    if (unlikely(!conn_.is_valid())) return MakeError(EINVAL);
+    if (unlikely(!conn_.is_valid())) {
+      if (Status<void> ret = TrySetupConn(false); !ret) return MakeError(ret);
+    }
     netaddr ra;
     Status<size_t> ret =
         conn_.ReadvFrom(iov, raddr ? &ra : nullptr, peek, nonblocking);
@@ -91,9 +92,7 @@ class UDPSocket : public Socket {
   Status<size_t> WriteTo(std::span<const std::byte> buf,
                          const SockAddrPtr raddr, bool nonblocking) override {
     if (!conn_.is_valid()) {
-      Status<rt::UDPConn> ret = rt::UDPConn::Listen({0, 0});
-      if (unlikely(!ret)) return MakeError(ret);
-      ReplaceConn(std::move(*ret));
+      if (Status<void> ret = TrySetupConn(true); !ret) return MakeError(ret);
     }
     if (raddr) {
       Status<netaddr> ra = raddr.ToNetAddr();
@@ -106,9 +105,7 @@ class UDPSocket : public Socket {
   Status<size_t> WritevTo(std::span<const iovec> iov, const SockAddrPtr raddr,
                           bool nonblocking) override {
     if (!conn_.is_valid()) {
-      Status<rt::UDPConn> ret = rt::UDPConn::Listen({0, 0});
-      if (unlikely(!ret)) return MakeError(ret);
-      ReplaceConn(std::move(*ret));
+      if (Status<void> ret = TrySetupConn(true); !ret) return MakeError(ret);
     }
 
     if (raddr) {
@@ -136,8 +133,12 @@ class UDPSocket : public Socket {
   }
 
   Status<void> LocalAddr(SockAddrPtr laddr) const override {
-    if (unlikely(!conn_.is_valid())) return MakeError(EINVAL);
     assert(laddr);
+    if (bind_token_.is_valid()) {
+      laddr.FromNetAddr(bind_token_.LocalAddr());
+      return {};
+    }
+    if (unlikely(!conn_.is_valid())) return MakeError(EINVAL);
     Status<netaddr> ret = conn_.LocalAddr();
     if (unlikely(!ret)) return MakeError(ret);
     laddr.FromNetAddr(*ret);
@@ -158,7 +159,20 @@ class UDPSocket : public Socket {
     }
   }
 
-  // TODO(jsf): Writev, WritevTo
+  Status<void> SetSockOpt(int level, int optname,
+                          std::span<const std::byte> optval) override {
+    if (level != SOL_SOCKET) return MakeError(EINVAL);
+    switch (optname) {
+      case SO_REUSEADDR:
+      case SO_REUSEPORT:
+        if (conn_.is_valid() || bind_token_.is_valid())
+          return MakeError(EINVAL);
+        reuse_port_ = *reinterpret_cast<const int *>(optval.data());
+        return {};
+      default:
+        return MakeError(EINVAL);
+    }
+  }
 
  private:
   void SetupPollSource() override {
@@ -175,30 +189,68 @@ class UDPSocket : public Socket {
     conn_.SetNonBlocking((newflags & kFlagNonblock) > 0);
   }
 
-  inline void ReplaceConn(rt::UDPConn &&new_conn) {
-    if (conn_.is_valid() && IsPollSourceSetup())
-      conn_.InstallPollSource(nullptr, nullptr, 0);
+  inline void InstallConn(rt::UDPConn &&new_conn) {
+    assert(!conn_.is_valid());
+    assert(!bind_token_.is_valid());
     conn_ = std::move(new_conn);
     if (is_nonblocking()) conn_.SetNonBlocking(true);
     if (IsPollSourceSetup()) SetupPollSource();
+  }
+
+  // UDP sockets can be initiated on the fly without calling connect.
+  Status<void> TrySetupConn(bool is_outbound) {
+    assert(!conn_.is_valid());
+    // An attempt to read without an already defined local port does not make
+    // sense, just return an error.
+    if (!bind_token_.is_valid() && !is_outbound) return MakeError(EINVAL);
+
+    Status<rt::UDPConn> ret;
+    if (bind_token_.is_valid()) {
+      ret = bind_token_.ListenUDP();
+    } else {
+      ret = rt::UDPConn::Listen({});
+    }
+
+    if (unlikely(!ret)) return MakeError(ret);
+    InstallConn(std::move(*ret));
+    return {};
   }
 
   friend class cereal::access;
 
   template <class Archive>
   void save(Archive &ar) const {
-    ar(cereal::base_class<Socket>(this), conn_.is_valid());
-    if (conn_.is_valid()) ar(conn_.LocalAddr(), conn_.RemoteAddr(), is_shut_);
+    ar(cereal::base_class<Socket>(this), conn_.is_valid(),
+       bind_token_.is_valid(), reuse_port_);
+    if (conn_.is_valid())
+      ar(conn_.LocalAddr(), conn_.RemoteAddr(), is_shut_);
+    else if (bind_token_.is_valid())
+      ar(bind_token_.LocalAddr());
   }
 
   template <class Archive>
   void load(Archive &ar) {
-    bool is_valid;
-    ar(cereal::base_class<Socket>(this), is_valid);
-    if (!is_valid) return;
+    bool conn_is_valid, bind_token_is_valid;
+    ar(cereal::base_class<Socket>(this), conn_is_valid, bind_token_is_valid,
+       reuse_port_);
 
-    netaddr laddr;
-    netaddr raddr;
+    netaddr laddr, raddr;
+
+    if (bind_token_is_valid) {
+      assert(!conn_.is_valid());
+      ar(laddr);
+      Status<rt::BindToken> ret =
+          rt::BindToken::AllocateUDP(laddr, reuse_port_);
+      if (unlikely(!ret)) {
+        LOG(ERR) << "failed to restore UDP bind token @ " << laddr.ip << ":"
+                 << laddr.port;
+        BUG();
+      }
+      bind_token_ = std::move(*ret);
+      return;
+    }
+
+    if (!conn_is_valid) return;
 
     ar(laddr, raddr, is_shut_);
 
@@ -220,7 +272,7 @@ class UDPSocket : public Socket {
     }
 
     if (is_shut_) ret->Shutdown();
-    ReplaceConn(std::move(*ret));
+    InstallConn(std::move(*ret));
   }
 
   // This may or may not be valid. If UDPSocket is created without a rt::UDPConn
@@ -228,7 +280,9 @@ class UDPSocket : public Socket {
   // Otherwise, UDPSocket will be created with a valid rt::UDPConn which will be
   // stored here (as a result of Bind/Connect calls).
   rt::UDPConn conn_;
+  rt::BindToken bind_token_;
   std::atomic_bool is_shut_{false};
+  bool reuse_port_{false};
 };
 
 }  // namespace junction

--- a/junction/net/udp_socket.h
+++ b/junction/net/udp_socket.h
@@ -23,23 +23,26 @@ class UDPSocket : public Socket {
     if (unlikely(conn_.is_valid())) return MakeError(EINVAL);
     Status<netaddr> na = addr.ToNetAddr();
     if (unlikely(!na)) return MakeError(na);
-    Status<rt::BindToken> ret = rt::BindToken::AllocateUDP(*na, reuse_port());
+    Status<rt::BindToken> token = rt::BindToken::AllocateUDP(*na, reuse_port());
+    if (unlikely(!token)) return MakeError(token);
+    Status<rt::UDPConn> ret = token->ListenUDP();
     if (unlikely(!ret)) return MakeError(ret);
-    bind_token_ = std::move(*ret);
+    InstallConn(std::move(*ret));
     return {};
   }
 
   Status<void> Connect(const SockAddrPtr addr) override {
-    if (unlikely(conn_.is_valid())) return MakeError(EISCONN);
+    netaddr laddr;
+    if (conn_.is_valid()) {
+      netaddr remote = conn_.RemoteAddr();
+      if (unlikely(remote.ip || remote.port)) return MakeError(EISCONN);
+      laddr = conn_.LocalAddr();
+    } else {
+      laddr = {0, 0};
+    }
     Status<netaddr> raddr = addr.ToNetAddr();
     if (unlikely(!raddr)) return MakeError(raddr);
-
-    Status<rt::UDPConn> ret;
-    if (bind_token_.is_valid())
-      ret = bind_token_.DialUDP(*raddr);
-    else
-      ret = rt::UDPConn::Dial({}, *raddr);
-
+    Status<rt::UDPConn> ret = rt::UDPConn::Dial(laddr, *raddr);
     if (unlikely(!ret)) return MakeError(ret);
     InstallConn(std::move(*ret));
     return {};
@@ -68,9 +71,7 @@ class UDPSocket : public Socket {
 
   Status<size_t> ReadFrom(std::span<std::byte> buf, SockAddrPtr raddr,
                           bool peek, bool nonblocking) override {
-    if (unlikely(!conn_.is_valid())) {
-      if (Status<void> ret = TrySetupConn(false); !ret) return MakeError(ret);
-    }
+    if (unlikely(!conn_.is_valid())) return MakeError(EINVAL);
     netaddr ra;
     rt::RuntimeWaitqTimeout timeout(read_timeout());
     Status<size_t> ret =
@@ -82,9 +83,7 @@ class UDPSocket : public Socket {
 
   Status<size_t> ReadvFrom(std::span<iovec> iov, SockAddrPtr raddr, bool peek,
                            bool nonblocking) override {
-    if (unlikely(!conn_.is_valid())) {
-      if (Status<void> ret = TrySetupConn(false); !ret) return MakeError(ret);
-    }
+    if (unlikely(!conn_.is_valid())) return MakeError(EINVAL);
     netaddr ra;
     rt::RuntimeWaitqTimeout timeout(read_timeout());
     Status<size_t> ret =
@@ -97,7 +96,7 @@ class UDPSocket : public Socket {
   Status<size_t> WriteTo(std::span<const std::byte> buf,
                          const SockAddrPtr raddr, bool nonblocking) override {
     if (!conn_.is_valid()) {
-      if (Status<void> ret = TrySetupConn(true); !ret) return MakeError(ret);
+      if (Status<void> ret = TrySetupConn(); !ret) return MakeError(ret);
     }
     rt::RuntimeWaitqTimeout timeout(write_timeout());
     if (raddr) {
@@ -111,7 +110,7 @@ class UDPSocket : public Socket {
   Status<size_t> WritevTo(std::span<const iovec> iov, const SockAddrPtr raddr,
                           bool nonblocking) override {
     if (!conn_.is_valid()) {
-      if (Status<void> ret = TrySetupConn(true); !ret) return MakeError(ret);
+      if (Status<void> ret = TrySetupConn(); !ret) return MakeError(ret);
     }
     rt::RuntimeWaitqTimeout timeout(write_timeout());
     if (raddr) {
@@ -140,10 +139,6 @@ class UDPSocket : public Socket {
 
   Status<void> LocalAddr(SockAddrPtr laddr) const override {
     assert(laddr);
-    if (bind_token_.is_valid()) {
-      laddr.FromNetAddr(bind_token_.LocalAddr());
-      return {};
-    }
     if (unlikely(!conn_.is_valid())) return MakeError(EINVAL);
     Status<netaddr> ret = conn_.LocalAddr();
     if (unlikely(!ret)) return MakeError(ret);
@@ -176,7 +171,6 @@ class UDPSocket : public Socket {
 
  private:
   void SetupPollSource() override {
-    if (!conn_.is_valid()) return;
     PollSource &s = get_poll_source();
     conn_.InstallPollSource(PollSourceSet, PollSourceClear,
                             reinterpret_cast<unsigned long>(&s));
@@ -190,27 +184,17 @@ class UDPSocket : public Socket {
   }
 
   inline void InstallConn(rt::UDPConn &&new_conn) {
-    assert(!conn_.is_valid());
-    assert(!bind_token_.is_valid());
+    if (conn_.is_valid() && IsPollSourceSetup())
+      conn_.InstallPollSource(nullptr, nullptr, 0);
     conn_ = std::move(new_conn);
     if (is_nonblocking()) conn_.SetNonBlocking(true);
     if (IsPollSourceSetup()) SetupPollSource();
   }
 
-  // UDP sockets can be initiated on the fly without calling connect.
-  Status<void> TrySetupConn(bool is_outbound) {
+  // UDP sockets can be initiated on the fly without calling bind/connect.
+  Status<void> TrySetupConn() {
     assert(!conn_.is_valid());
-    // An attempt to read without an already defined local port does not make
-    // sense, just return an error.
-    if (!bind_token_.is_valid() && !is_outbound) return MakeError(EINVAL);
-
-    Status<rt::UDPConn> ret;
-    if (bind_token_.is_valid()) {
-      ret = bind_token_.ListenUDP();
-    } else {
-      ret = rt::UDPConn::Listen({});
-    }
-
+    Status<rt::UDPConn> ret = rt::UDPConn::Listen({});
     if (unlikely(!ret)) return MakeError(ret);
     InstallConn(std::move(*ret));
     return {};
@@ -220,36 +204,17 @@ class UDPSocket : public Socket {
 
   template <class Archive>
   void save(Archive &ar) const {
-    ar(cereal::base_class<Socket>(this), conn_.is_valid(),
-       bind_token_.is_valid());
-    if (conn_.is_valid())
-      ar(conn_.LocalAddr(), conn_.RemoteAddr(), is_shut_);
-    else if (bind_token_.is_valid())
-      ar(bind_token_.LocalAddr());
+    ar(cereal::base_class<Socket>(this), conn_.is_valid());
+    if (conn_.is_valid()) ar(conn_.LocalAddr(), conn_.RemoteAddr(), is_shut_);
   }
 
   template <class Archive>
   void load(Archive &ar) {
-    bool conn_is_valid, bind_token_is_valid;
-    ar(cereal::base_class<Socket>(this), conn_is_valid, bind_token_is_valid);
+    bool conn_is_valid;
+    ar(cereal::base_class<Socket>(this), conn_is_valid);
+    if (!conn_is_valid) return;
 
     netaddr laddr, raddr;
-
-    if (bind_token_is_valid) {
-      assert(!conn_.is_valid());
-      ar(laddr);
-      Status<rt::BindToken> ret =
-          rt::BindToken::AllocateUDP(laddr, reuse_port());
-      if (unlikely(!ret)) {
-        LOG(ERR) << "failed to restore UDP bind token @ " << laddr.ip << ":"
-                 << laddr.port;
-        BUG();
-      }
-      bind_token_ = std::move(*ret);
-      return;
-    }
-
-    if (!conn_is_valid) return;
 
     ar(laddr, raddr, is_shut_);
 
@@ -279,7 +244,6 @@ class UDPSocket : public Socket {
   // Otherwise, UDPSocket will be created with a valid rt::UDPConn which will be
   // stored here (as a result of Bind/Connect calls).
   rt::UDPConn conn_;
-  rt::BindToken bind_token_;
   std::atomic_bool is_shut_{false};
 };
 

--- a/junction/net/udp_socket.h
+++ b/junction/net/udp_socket.h
@@ -13,9 +13,9 @@
 
 namespace junction {
 
-class UDPSocket : public Socket {
+class UDPSocket : public IPSocket {
  public:
-  UDPSocket(int flags = 0) noexcept : Socket(flags) {}
+  UDPSocket(int flags = 0) noexcept : IPSocket(flags) {}
   ~UDPSocket() override = default;
 
   Status<void> Bind(const SockAddrPtr addr) override {
@@ -82,12 +82,12 @@ class UDPSocket : public Socket {
   }
 
   Status<size_t> ReadvFrom(std::span<iovec> iov, SockAddrPtr raddr, bool peek,
-                           bool nonblocking) override {
+                           bool nonblocking, aux_rx_pkt_data *aux) override {
     if (unlikely(!conn_.is_valid())) return MakeError(EINVAL);
     netaddr ra;
     rt::RuntimeWaitqTimeout timeout(read_timeout());
     Status<size_t> ret =
-        conn_.ReadvFrom(iov, raddr ? &ra : nullptr, peek, nonblocking);
+        conn_.ReadvFrom(iov, raddr ? &ra : nullptr, peek, nonblocking, aux);
     if (unlikely(!ret)) return ret;
     if (raddr) raddr.FromNetAddr(ra);
     return ret;
@@ -108,7 +108,7 @@ class UDPSocket : public Socket {
   }
 
   Status<size_t> WritevTo(std::span<const iovec> iov, const SockAddrPtr raddr,
-                          bool nonblocking) override {
+                          bool nonblocking, aux_tx_pkt_data *aux) override {
     if (!conn_.is_valid()) {
       if (Status<void> ret = TrySetupConn(); !ret) return MakeError(ret);
     }
@@ -116,9 +116,9 @@ class UDPSocket : public Socket {
     if (raddr) {
       Status<netaddr> ra = raddr.ToNetAddr();
       if (unlikely(!ra)) return MakeError(ra);
-      return conn_.WritevTo(iov, &*ra, nonblocking);
+      return conn_.WritevTo(iov, &*ra, nonblocking, aux);
     }
-    return conn_.WritevTo(iov, nullptr, nonblocking);
+    return conn_.WritevTo(iov, nullptr, nonblocking, aux);
   }
 
   Status<void> Shutdown([[maybe_unused]] int how) override {
@@ -204,14 +204,14 @@ class UDPSocket : public Socket {
 
   template <class Archive>
   void save(Archive &ar) const {
-    ar(cereal::base_class<Socket>(this), conn_.is_valid());
+    ar(cereal::base_class<IPSocket>(this), conn_.is_valid());
     if (conn_.is_valid()) ar(conn_.LocalAddr(), conn_.RemoteAddr(), is_shut_);
   }
 
   template <class Archive>
   void load(Archive &ar) {
     bool conn_is_valid;
-    ar(cereal::base_class<Socket>(this), conn_is_valid);
+    ar(cereal::base_class<IPSocket>(this), conn_is_valid);
     if (!conn_is_valid) return;
 
     netaddr laddr, raddr;

--- a/junction/net/udp_socket_test.cc
+++ b/junction/net/udp_socket_test.cc
@@ -57,14 +57,14 @@ std::string DiscoverSpecificIP() {
   inet_pton(AF_INET, "8.8.8.8", &serv.sin_addr);  // Google's DNS
 
   // "Connect" (no packets actually sent yet)
-  if (connect(sock, (struct sockaddr*)&serv, sizeof(serv)) < 0) {
+  if (connect(sock, (struct sockaddr *)&serv, sizeof(serv)) < 0) {
     perror("connect");
     close(sock);
     exit(1);
   }
 
   // Get local address
-  if (getsockname(sock, (struct sockaddr*)&name, &namelen) == -1) {
+  if (getsockname(sock, (struct sockaddr *)&name, &namelen) == -1) {
     perror("getsockname");
     close(sock);
     exit(1);
@@ -94,11 +94,9 @@ class UDPSocketTest : public ::testing::Test {
   int GetNextPort() { return port_counter_++; }
 
   // Helper function to create and bind a socket
-  int CreateBoundSocket(const std::string& bind_addr, int port) {
+  int CreateBoundSocket(const std::string &bind_addr, int port) {
     int fd = socket(AF_INET, SOCK_DGRAM, 0);
-    if (fd == -1) {
-      return -1;
-    }
+    if (fd == -1) { return -1; }
 
     int yes = 1;
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) == -1) {
@@ -116,7 +114,7 @@ class UDPSocketTest : public ::testing::Test {
       return -1;
     }
 
-    if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+    if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
       close(fd);
       return -1;
     }
@@ -125,11 +123,9 @@ class UDPSocketTest : public ::testing::Test {
   }
 
   // Helper function to create a connected socket
-  int CreateConnectedSocket(const std::string& target_addr, int port) {
+  int CreateConnectedSocket(const std::string &target_addr, int port) {
     int fd = socket(AF_INET, SOCK_DGRAM, 0);
-    if (fd == -1) {
-      return -1;
-    }
+    if (fd == -1) { return -1; }
 
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(addr));
@@ -141,7 +137,7 @@ class UDPSocketTest : public ::testing::Test {
       return -1;
     }
 
-    if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+    if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
       close(fd);
       return -1;
     }
@@ -150,7 +146,7 @@ class UDPSocketTest : public ::testing::Test {
   }
 
   // Test sendto/recvfrom combination
-  void TestSendtoRecvfrom(const TestConfig& config) {
+  void TestSendtoRecvfrom(const TestConfig &config) {
     int server_fd = -1, client_fd = -1;
 
     // Create server socket
@@ -194,7 +190,7 @@ class UDPSocketTest : public ::testing::Test {
         sent = send(client_fd, send_buf, MESSAGE_SIZE, 0);
       } else {
         sent = sendto(client_fd, send_buf, MESSAGE_SIZE, 0,
-                      (struct sockaddr*)&target_addr, sizeof(target_addr));
+                      (struct sockaddr *)&target_addr, sizeof(target_addr));
       }
       EXPECT_EQ(sent, MESSAGE_SIZE) << "Send failed on iteration " << i;
 
@@ -202,7 +198,7 @@ class UDPSocketTest : public ::testing::Test {
       struct sockaddr_in from_addr;
       socklen_t from_len = sizeof(from_addr);
       ssize_t received = recvfrom(server_fd, recv_buf, MESSAGE_SIZE, 0,
-                                  (struct sockaddr*)&from_addr, &from_len);
+                                  (struct sockaddr *)&from_addr, &from_len);
       EXPECT_EQ(received, MESSAGE_SIZE) << "Recvfrom failed on iteration " << i;
 
       // Verify data
@@ -211,7 +207,7 @@ class UDPSocketTest : public ::testing::Test {
 
       // Send response back
       ssize_t response_sent = sendto(server_fd, recv_buf, MESSAGE_SIZE, 0,
-                                     (struct sockaddr*)&from_addr, from_len);
+                                     (struct sockaddr *)&from_addr, from_len);
       EXPECT_EQ(response_sent, MESSAGE_SIZE)
           << "Response send failed on iteration " << i;
 
@@ -232,7 +228,7 @@ class UDPSocketTest : public ::testing::Test {
   }
 
   // Test send/recv combination (for connected sockets)
-  void TestSendRecv(const TestConfig& config) {
+  void TestSendRecv(const TestConfig &config) {
     ASSERT_TRUE(config.use_connected_socket)
         << "TestSendRecv requires connected socket";
 
@@ -265,7 +261,7 @@ class UDPSocketTest : public ::testing::Test {
       struct sockaddr_in from_addr;
       socklen_t from_len = sizeof(from_addr);
       ssize_t received = recvfrom(server_fd, recv_buf, MESSAGE_SIZE, 0,
-                                  (struct sockaddr*)&from_addr, &from_len);
+                                  (struct sockaddr *)&from_addr, &from_len);
       EXPECT_EQ(received, MESSAGE_SIZE) << "Recvfrom failed on iteration " << i;
 
       // Verify data
@@ -297,7 +293,7 @@ class UDPSocketTest : public ::testing::Test {
     inet_pton(AF_INET, custom_ip_.c_str(), &target_addr.sin_addr);
 
     ssize_t sent = sendto(localhost_fd, send_buf, MESSAGE_SIZE, 0,
-                          (struct sockaddr*)&target_addr, sizeof(target_addr));
+                          (struct sockaddr *)&target_addr, sizeof(target_addr));
     EXPECT_EQ(sent, MESSAGE_SIZE) << "Failed to send to custom IP";
 
     // Try to receive on localhost socket - should timeout or fail
@@ -386,7 +382,7 @@ TEST_F(UDPSocketTest, MixedSyscalls_ConnectedSocket) {
       target_addr.sin_port = htons(portno);
       inet_pton(AF_INET, "127.0.0.1", &target_addr.sin_addr);
       sent = sendto(client_fd, send_buf, MESSAGE_SIZE, 0,
-                    (struct sockaddr*)&target_addr, sizeof(target_addr));
+                    (struct sockaddr *)&target_addr, sizeof(target_addr));
     }
     EXPECT_EQ(sent, MESSAGE_SIZE) << "Send failed on iteration " << i;
 
@@ -394,7 +390,7 @@ TEST_F(UDPSocketTest, MixedSyscalls_ConnectedSocket) {
     struct sockaddr_in from_addr;
     socklen_t from_len = sizeof(from_addr);
     ssize_t received = recvfrom(server_fd, recv_buf, MESSAGE_SIZE, 0,
-                                (struct sockaddr*)&from_addr, &from_len);
+                                (struct sockaddr *)&from_addr, &from_len);
     EXPECT_EQ(received, MESSAGE_SIZE) << "Recvfrom failed on iteration " << i;
   }
 
@@ -435,13 +431,13 @@ TEST_F(UDPSocketTest, LargeMessage) {
   inet_pton(AF_INET, "127.0.0.1", &target_addr.sin_addr);
 
   ssize_t sent = sendto(client_fd, send_buf, large_size, 0,
-                        (struct sockaddr*)&target_addr, sizeof(target_addr));
+                        (struct sockaddr *)&target_addr, sizeof(target_addr));
   EXPECT_EQ(sent, large_size) << "Failed to send large message";
 
   struct sockaddr_in from_addr;
   socklen_t from_len = sizeof(from_addr);
   ssize_t received = recvfrom(server_fd, recv_buf, large_size, 0,
-                              (struct sockaddr*)&from_addr, &from_len);
+                              (struct sockaddr *)&from_addr, &from_len);
   EXPECT_EQ(received, large_size) << "Failed to receive large message";
 
   EXPECT_EQ(memcmp(send_buf, recv_buf, large_size), 0)

--- a/junction/net/udp_socket_test.cc
+++ b/junction/net/udp_socket_test.cc
@@ -1,0 +1,452 @@
+// Comprehensive UDP socket tests covering different bind addresses,
+// syscall combinations, and socket configurations
+
+extern "C" {
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+}
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <future>
+#include <string>
+#include <thread>
+#include <vector>
+
+const int TEST_PORT_BASE = 8000;
+const int MESSAGE_SIZE = 64;
+const int TEST_MESSAGES = 10;
+
+// Test configuration structure
+struct TestConfig {
+  std::string bind_addr;
+  std::string target_addr;
+  int port;
+  bool use_connected_socket;
+  bool bind_socket;
+  std::string test_name;
+};
+
+std::string DiscoverSpecificIP() {
+  int sock;
+  struct sockaddr_in serv, name;
+  socklen_t namelen = sizeof(name);
+
+  // Create UDP socket
+  sock = socket(AF_INET, SOCK_DGRAM, 0);
+  if (sock < 0) {
+    perror("socket");
+    exit(1);
+  }
+
+  memset(&serv, 0, sizeof(serv));
+  serv.sin_family = AF_INET;
+  serv.sin_port = htons(53);                      // DNS port
+  inet_pton(AF_INET, "8.8.8.8", &serv.sin_addr);  // Google's DNS
+
+  // "Connect" (no packets actually sent yet)
+  if (connect(sock, (struct sockaddr*)&serv, sizeof(serv)) < 0) {
+    perror("connect");
+    close(sock);
+    exit(1);
+  }
+
+  // Get local address
+  if (getsockname(sock, (struct sockaddr*)&name, &namelen) == -1) {
+    perror("getsockname");
+    close(sock);
+    exit(1);
+  }
+
+  char ip[INET_ADDRSTRLEN];
+  if (inet_ntop(AF_INET, &name.sin_addr, ip, sizeof(ip)) == NULL) {
+    perror("inet_ntop");
+    close(sock);
+    exit(1);
+  }
+
+  close(sock);
+  return ip;
+}
+
+class UDPSocketTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Get the custom IP address from environment or use default
+    custom_ip_ = DiscoverSpecificIP();
+  }
+
+  std::string custom_ip_;
+  int port_counter_ = TEST_PORT_BASE;
+
+  int GetNextPort() { return port_counter_++; }
+
+  // Helper function to create and bind a socket
+  int CreateBoundSocket(const std::string& bind_addr, int port) {
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd == -1) {
+      return -1;
+    }
+
+    int yes = 1;
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) == -1) {
+      close(fd);
+      return -1;
+    }
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+
+    if (inet_pton(AF_INET, bind_addr.c_str(), &addr.sin_addr) != 1) {
+      close(fd);
+      return -1;
+    }
+
+    if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+      close(fd);
+      return -1;
+    }
+
+    return fd;
+  }
+
+  // Helper function to create a connected socket
+  int CreateConnectedSocket(const std::string& target_addr, int port) {
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd == -1) {
+      return -1;
+    }
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+
+    if (inet_pton(AF_INET, target_addr.c_str(), &addr.sin_addr) != 1) {
+      close(fd);
+      return -1;
+    }
+
+    if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
+      close(fd);
+      return -1;
+    }
+
+    return fd;
+  }
+
+  // Test sendto/recvfrom combination
+  void TestSendtoRecvfrom(const TestConfig& config) {
+    int server_fd = -1, client_fd = -1;
+
+    // Create server socket
+    if (config.bind_socket) {
+      server_fd = CreateBoundSocket(config.bind_addr, config.port);
+      ASSERT_NE(server_fd, -1) << "Failed to create bound server socket";
+    } else {
+      server_fd = socket(AF_INET, SOCK_DGRAM, 0);
+      ASSERT_NE(server_fd, -1) << "Failed to create server socket";
+    }
+
+    // Create client socket
+    if (config.use_connected_socket) {
+      client_fd = CreateConnectedSocket(config.target_addr, config.port);
+      ASSERT_NE(client_fd, -1) << "Failed to create connected client socket";
+    } else {
+      client_fd = socket(AF_INET, SOCK_DGRAM, 0);
+      ASSERT_NE(client_fd, -1) << "Failed to create client socket";
+    }
+
+    // Test communication
+    char send_buf[MESSAGE_SIZE];
+    char recv_buf[MESSAGE_SIZE];
+    memset(send_buf, 'A', MESSAGE_SIZE);
+    memset(recv_buf, 0, MESSAGE_SIZE);
+
+    struct sockaddr_in target_addr;
+    memset(&target_addr, 0, sizeof(target_addr));
+    target_addr.sin_family = AF_INET;
+    target_addr.sin_port = htons(config.port);
+    // check for er
+    if (inet_pton(AF_INET, config.target_addr.c_str(), &target_addr.sin_addr) !=
+        1) {
+      ASSERT_TRUE(false) << "Invalid target address: " << config.target_addr;
+    }
+
+    for (int i = 0; i < TEST_MESSAGES; i++) {
+      // Send from client
+      ssize_t sent = 0;
+      if (config.use_connected_socket) {
+        sent = send(client_fd, send_buf, MESSAGE_SIZE, 0);
+      } else {
+        sent = sendto(client_fd, send_buf, MESSAGE_SIZE, 0,
+                      (struct sockaddr*)&target_addr, sizeof(target_addr));
+      }
+      EXPECT_EQ(sent, MESSAGE_SIZE) << "Send failed on iteration " << i;
+
+      // Receive on server
+      struct sockaddr_in from_addr;
+      socklen_t from_len = sizeof(from_addr);
+      ssize_t received = recvfrom(server_fd, recv_buf, MESSAGE_SIZE, 0,
+                                  (struct sockaddr*)&from_addr, &from_len);
+      EXPECT_EQ(received, MESSAGE_SIZE) << "Recvfrom failed on iteration " << i;
+
+      // Verify data
+      EXPECT_EQ(memcmp(send_buf, recv_buf, MESSAGE_SIZE), 0)
+          << "Data mismatch on iteration " << i;
+
+      // Send response back
+      ssize_t response_sent = sendto(server_fd, recv_buf, MESSAGE_SIZE, 0,
+                                     (struct sockaddr*)&from_addr, from_len);
+      EXPECT_EQ(response_sent, MESSAGE_SIZE)
+          << "Response send failed on iteration " << i;
+
+      // Receive response on client
+      ssize_t response_received = 0;
+      if (config.use_connected_socket) {
+        response_received = recv(client_fd, recv_buf, MESSAGE_SIZE, 0);
+      } else {
+        response_received =
+            recvfrom(client_fd, recv_buf, MESSAGE_SIZE, 0, NULL, NULL);
+      }
+      EXPECT_EQ(response_received, MESSAGE_SIZE)
+          << "Response recv failed on iteration " << i;
+    }
+
+    close(server_fd);
+    close(client_fd);
+  }
+
+  // Test send/recv combination (for connected sockets)
+  void TestSendRecv(const TestConfig& config) {
+    ASSERT_TRUE(config.use_connected_socket)
+        << "TestSendRecv requires connected socket";
+
+    int server_fd = -1, client_fd = -1;
+
+    // Create server socket
+    if (config.bind_socket) {
+      server_fd = CreateBoundSocket(config.bind_addr, config.port);
+      ASSERT_NE(server_fd, -1) << "Failed to create bound server socket";
+    } else {
+      server_fd = socket(AF_INET, SOCK_DGRAM, 0);
+      ASSERT_NE(server_fd, -1) << "Failed to create server socket";
+    }
+
+    // Create connected client socket
+    client_fd = CreateConnectedSocket(config.target_addr, config.port);
+    ASSERT_NE(client_fd, -1) << "Failed to create connected client socket";
+
+    char send_buf[MESSAGE_SIZE];
+    char recv_buf[MESSAGE_SIZE];
+    memset(send_buf, 'B', MESSAGE_SIZE);
+    memset(recv_buf, 0, MESSAGE_SIZE);
+
+    for (int i = 0; i < TEST_MESSAGES; i++) {
+      // Send from client
+      ssize_t sent = send(client_fd, send_buf, MESSAGE_SIZE, 0);
+      EXPECT_EQ(sent, MESSAGE_SIZE) << "Send failed on iteration " << i;
+
+      // Receive on server
+      struct sockaddr_in from_addr;
+      socklen_t from_len = sizeof(from_addr);
+      ssize_t received = recvfrom(server_fd, recv_buf, MESSAGE_SIZE, 0,
+                                  (struct sockaddr*)&from_addr, &from_len);
+      EXPECT_EQ(received, MESSAGE_SIZE) << "Recvfrom failed on iteration " << i;
+
+      // Verify data
+      EXPECT_EQ(memcmp(send_buf, recv_buf, MESSAGE_SIZE), 0)
+          << "Data mismatch on iteration " << i;
+    }
+
+    close(server_fd);
+    close(client_fd);
+  }
+
+  // Test address isolation - ensure 127.0.0.1 doesn't receive 192.168.127.7
+  // traffic
+  void TestAddressIsolation() {
+    int localhost_fd = CreateBoundSocket("127.0.0.1", GetNextPort());
+    ASSERT_NE(localhost_fd, -1) << "Failed to create localhost socket";
+
+    int custom_fd = CreateBoundSocket(custom_ip_, GetNextPort());
+    ASSERT_NE(custom_fd, -1) << "Failed to create custom IP socket";
+
+    char send_buf[MESSAGE_SIZE];
+    memset(send_buf, 'C', MESSAGE_SIZE);
+
+    // Send to custom IP from localhost
+    struct sockaddr_in target_addr;
+    memset(&target_addr, 0, sizeof(target_addr));
+    target_addr.sin_family = AF_INET;
+    target_addr.sin_port = htons(GetNextPort());
+    inet_pton(AF_INET, custom_ip_.c_str(), &target_addr.sin_addr);
+
+    ssize_t sent = sendto(localhost_fd, send_buf, MESSAGE_SIZE, 0,
+                          (struct sockaddr*)&target_addr, sizeof(target_addr));
+    EXPECT_EQ(sent, MESSAGE_SIZE) << "Failed to send to custom IP";
+
+    // Try to receive on localhost socket - should timeout or fail
+    fd_set readfds;
+    FD_ZERO(&readfds);
+    FD_SET(localhost_fd, &readfds);
+
+    struct timeval timeout;
+    timeout.tv_sec = 1;
+    timeout.tv_usec = 0;
+
+    int result = select(localhost_fd + 1, &readfds, NULL, NULL, &timeout);
+    EXPECT_EQ(result, 0)
+        << "Localhost socket should not receive custom IP traffic";
+
+    close(localhost_fd);
+    close(custom_fd);
+  }
+};
+
+// Test cases for different bind addresses
+TEST_F(UDPSocketTest, BindAnyAddress_SendtoRecvfrom) {
+  TestConfig config = {"0.0.0.0", "127.0.0.1", GetNextPort(),
+                       false,     true,        "BindAny_SendtoRecvfrom"};
+  TestSendtoRecvfrom(config);
+}
+
+TEST_F(UDPSocketTest, BindLocalhost_SendtoRecvfrom) {
+  TestConfig config = {"127.0.0.1",   "127.0.0.1",
+                       GetNextPort(), false,
+                       true,          "BindLocalhost_SendtoRecvfrom"};
+  TestSendtoRecvfrom(config);
+}
+
+TEST_F(UDPSocketTest, BindCustomIP_SendtoRecvfrom) {
+  TestConfig config = {custom_ip_, custom_ip_, GetNextPort(),
+                       false,      true,       "BindCustomIP_SendtoRecvfrom"};
+  TestSendtoRecvfrom(config);
+}
+
+// Test cases for connected sockets
+TEST_F(UDPSocketTest, ConnectedSocket_SendRecv) {
+  TestConfig config = {"127.0.0.1", "127.0.0.1", GetNextPort(),
+                       true,        true,        "Connected_SendRecv"};
+  TestSendRecv(config);
+}
+
+TEST_F(UDPSocketTest, ConnectedSocket_SendtoRecvfrom) {
+  TestConfig config = {"127.0.0.1", "127.0.0.1", GetNextPort(),
+                       true,        true,        "Connected_SendtoRecvfrom"};
+  TestSendtoRecvfrom(config);
+}
+
+// Test cases for different address combinations
+TEST_F(UDPSocketTest, BindAnyToSpecifiedIP) {
+  TestConfig config = {"0.0.0.0", custom_ip_, GetNextPort(),
+                       false,     true,       "BindAnyToSpecifiedIP"};
+  TestSendtoRecvfrom(config);
+}
+
+// Test address isolation
+TEST_F(UDPSocketTest, AddressIsolation) { TestAddressIsolation(); }
+
+// Test with different syscall combinations
+TEST_F(UDPSocketTest, MixedSyscalls_ConnectedSocket) {
+  int portno = GetNextPort();
+  int server_fd = CreateBoundSocket("127.0.0.1", portno);
+  ASSERT_NE(server_fd, -1) << "Failed to create server socket";
+
+  int client_fd = CreateConnectedSocket("127.0.0.1", portno);
+  ASSERT_NE(client_fd, -1) << "Failed to create client socket";
+
+  char send_buf[MESSAGE_SIZE];
+  char recv_buf[MESSAGE_SIZE];
+  memset(send_buf, 'D', MESSAGE_SIZE);
+
+  // Mix send/sendto and recv/recvfrom
+  for (int i = 0; i < TEST_MESSAGES; i++) {
+    ssize_t sent = 0;
+    if (i % 2 == 0) {
+      sent = send(client_fd, send_buf, MESSAGE_SIZE, 0);
+    } else {
+      struct sockaddr_in target_addr;
+      memset(&target_addr, 0, sizeof(target_addr));
+      target_addr.sin_family = AF_INET;
+      target_addr.sin_port = htons(portno);
+      inet_pton(AF_INET, "127.0.0.1", &target_addr.sin_addr);
+      sent = sendto(client_fd, send_buf, MESSAGE_SIZE, 0,
+                    (struct sockaddr*)&target_addr, sizeof(target_addr));
+    }
+    EXPECT_EQ(sent, MESSAGE_SIZE) << "Send failed on iteration " << i;
+
+    // Always use recvfrom on server side
+    struct sockaddr_in from_addr;
+    socklen_t from_len = sizeof(from_addr);
+    ssize_t received = recvfrom(server_fd, recv_buf, MESSAGE_SIZE, 0,
+                                (struct sockaddr*)&from_addr, &from_len);
+    EXPECT_EQ(received, MESSAGE_SIZE) << "Recvfrom failed on iteration " << i;
+  }
+
+  close(server_fd);
+  close(client_fd);
+}
+
+// Test with different port numbers
+TEST_F(UDPSocketTest, DifferentPorts) {
+  std::vector<int> ports = {8001, 8002, 8003, 8004, 8005};
+
+  for (int port : ports) {
+    TestConfig config = {"127.0.0.1", "127.0.0.1",
+                         port,        false,
+                         true,        "DifferentPort_" + std::to_string(port)};
+    TestSendtoRecvfrom(config);
+  }
+}
+
+// Test with large messages
+TEST_F(UDPSocketTest, LargeMessage) {
+  const int large_size = 1024;
+  char send_buf[large_size];
+  char recv_buf[large_size];
+  memset(send_buf, 'E', large_size);
+  int portno = GetNextPort();
+
+  int server_fd = CreateBoundSocket("127.0.0.1", portno);
+  ASSERT_NE(server_fd, -1) << "Failed to create server socket";
+
+  int client_fd = socket(AF_INET, SOCK_DGRAM, 0);
+  ASSERT_NE(client_fd, -1) << "Failed to create client socket";
+
+  struct sockaddr_in target_addr;
+  memset(&target_addr, 0, sizeof(target_addr));
+  target_addr.sin_family = AF_INET;
+  target_addr.sin_port = htons(portno);
+  inet_pton(AF_INET, "127.0.0.1", &target_addr.sin_addr);
+
+  ssize_t sent = sendto(client_fd, send_buf, large_size, 0,
+                        (struct sockaddr*)&target_addr, sizeof(target_addr));
+  EXPECT_EQ(sent, large_size) << "Failed to send large message";
+
+  struct sockaddr_in from_addr;
+  socklen_t from_len = sizeof(from_addr);
+  ssize_t received = recvfrom(server_fd, recv_buf, large_size, 0,
+                              (struct sockaddr*)&from_addr, &from_len);
+  EXPECT_EQ(received, large_size) << "Failed to receive large message";
+
+  EXPECT_EQ(memcmp(send_buf, recv_buf, large_size), 0)
+      << "Large message data mismatch";
+
+  close(server_fd);
+  close(client_fd);
+}

--- a/junction/net/unix_socket.cc
+++ b/junction/net/unix_socket.cc
@@ -726,6 +726,13 @@ class UnixStreamSocket : public Socket {
        cereal::base_class<Socket>(construct.ptr()));
   }
 
+ protected:
+  [[nodiscard]] Status<size_t> get_input_bytes() const override {
+    if (state_ == SocketState::kSockConnected)
+      return Connection().rx->get_readable_bytes();
+    return MakeError(EINVAL);
+  }
+
  private:
   [[nodiscard]] std::weak_ptr<UnixStreamSocket> weak_this() {
     return std::static_pointer_cast<UnixStreamSocket>(shared_from_this());

--- a/junction/net/unix_socket.cc
+++ b/junction/net/unix_socket.cc
@@ -16,6 +16,8 @@ void serialize(Archive &archive, UnixSocketAddr &a) {
   archive(std::get<0>(a), std::get<1>(a));
 }
 
+// TODO(jsf): implement timeout support for unix sockets.
+
 // Table that tracks unix sockets with abstract names (not file-system based)
 // for a given type of socket.
 template <class SockType>
@@ -312,24 +314,6 @@ class UnixDatagramSocket : public Socket {
     });
   }
 
-  Status<int> GetSockOpt(int level, int optname) const override {
-    if (level != SOL_SOCKET) return MakeError(EINVAL);
-    switch (optname) {
-      case SO_ACCEPTCONN:
-        return 0;
-      case SO_DOMAIN:
-        return AF_UNIX;
-      case SO_PROTOCOL:
-        return 0;
-      case SO_TYPE:
-        return SOCK_DGRAM;
-      case SO_ERROR:
-        return 0;
-      default:
-        return MakeError(EINVAL);
-    }
-  }
-
   template <class Archive>
   void save(Archive &ar) const {
     ar(rx_);
@@ -347,6 +331,35 @@ class UnixDatagramSocket : public Socket {
     UnixDatagramSocket &sock = *construct.ptr();
     ar(sock.local_name_, sock.remote_, sock.connected_, sock.dent_,
        sock.writer_closed_);
+  }
+
+ protected:
+  Status<size_t> GetSockOptImpl(int level, int optname,
+                                std::span<std::byte> value) const override {
+    if (level != SOL_SOCKET) return MakeError(EINVAL);
+    int ret;
+    switch (optname) {
+      case SO_ACCEPTCONN:
+        ret = 0;
+        break;
+      case SO_DOMAIN:
+        ret = AF_UNIX;
+        break;
+      case SO_PROTOCOL:
+        ret = 0;
+        break;
+      case SO_TYPE:
+        ret = SOCK_DGRAM;
+        break;
+      case SO_ERROR:
+        ret = 0;
+        break;
+      default:
+        return MakeError(EINVAL);
+    }
+    if (value.size() < sizeof(int)) return MakeError(EINVAL);
+    *reinterpret_cast<int *>(value.data()) = ret;
+    return sizeof(int);
   }
 
  private:
@@ -681,24 +694,6 @@ class UnixStreamSocket : public Socket {
     return Connection().rx->Readv(iov, is_nonblocking(), false);
   }
 
-  Status<int> GetSockOpt(int level, int optname) const override {
-    if (level != SOL_SOCKET) return MakeError(EINVAL);
-    switch (optname) {
-      case SO_ACCEPTCONN:
-        return state_ == SocketState::kSockListening ? 1 : 0;
-      case SO_DOMAIN:
-        return AF_UNIX;
-      case SO_PROTOCOL:
-        return 0;
-      case SO_TYPE:
-        return SOCK_STREAM;
-      case SO_ERROR:
-        return 0;
-      default:
-        return MakeError(EINVAL);
-    }
-  }
-
   [[nodiscard]] UnixStreamListener &Listener() {
     return std::get<UnixStreamListener>(v_);
   }
@@ -731,6 +726,34 @@ class UnixStreamSocket : public Socket {
     if (state_ == SocketState::kSockConnected)
       return Connection().rx->get_readable_bytes();
     return MakeError(EINVAL);
+  }
+
+  Status<size_t> GetSockOptImpl(int level, int optname,
+                                std::span<std::byte> value) const override {
+    if (level != SOL_SOCKET) return MakeError(EINVAL);
+    int ret;
+    switch (optname) {
+      case SO_ACCEPTCONN:
+        ret = state_ == SocketState::kSockListening ? 1 : 0;
+        break;
+      case SO_DOMAIN:
+        ret = AF_UNIX;
+        break;
+      case SO_PROTOCOL:
+        ret = 0;
+        break;
+      case SO_TYPE:
+        ret = SOCK_STREAM;
+        break;
+      case SO_ERROR:
+        ret = 0;
+        break;
+      default:
+        return MakeError(EINVAL);
+    }
+    if (value.size() < sizeof(int)) return MakeError(EINVAL);
+    *reinterpret_cast<int *>(value.data()) = ret;
+    return sizeof(int);
   }
 
  private:

--- a/junction/net/unix_socket.cc
+++ b/junction/net/unix_socket.cc
@@ -253,7 +253,8 @@ class UnixDatagramSocket : public Socket {
   }
 
   Status<size_t> ReadvFrom(std::span<iovec> iov, SockAddrPtr raddr, bool peek,
-                           bool nonblocking) override {
+                           bool nonblocking,
+                           [[maybe_unused]] aux_rx_pkt_data *aux) override {
     UnixSocketAddr rem;
     nonblocking |= is_nonblocking();
     Status<size_t> ret = rx_->DoRead(nonblocking, [&](DatagramChannel &chan) {
@@ -303,7 +304,8 @@ class UnixDatagramSocket : public Socket {
   }
 
   Status<size_t> WritevTo(std::span<const iovec> iov, const SockAddrPtr raddr,
-                          bool nonblocking) override {
+                          bool nonblocking,
+                          [[maybe_unused]] aux_tx_pkt_data *aux) override {
     if (writer_closed_) return MakeError(EPIPE);
     Status<std::shared_ptr<UnixDatagramSocket>> tmp = ResolvePeer(raddr);
     if (!tmp) return MakeError(tmp);
@@ -663,7 +665,8 @@ class UnixStreamSocket : public Socket {
   }
 
   Status<size_t> WritevTo(std::span<const iovec> iov, const SockAddrPtr raddr,
-                          bool nonblocking) override {
+                          bool nonblocking,
+                          [[maybe_unused]] aux_tx_pkt_data *aux) override {
     if (unlikely(state_ != SocketState::kSockConnected))
       return MakeError(EINVAL);
     if (raddr) return MakeError(EISCONN);
@@ -679,7 +682,8 @@ class UnixStreamSocket : public Socket {
   }
 
   Status<size_t> ReadvFrom(std::span<iovec> iov, SockAddrPtr raddr, bool peek,
-                           bool nonblocking) override {
+                           bool nonblocking,
+                           [[maybe_unused]] aux_rx_pkt_data *aux) override {
     if (unlikely(state_ != SocketState::kSockConnected))
       return MakeError(EINVAL);
     if (raddr) raddr.FromUnixAddr(Connection().peer_name);

--- a/junction/run.cc
+++ b/junction/run.cc
@@ -16,10 +16,36 @@ namespace junction {
 
 Status<std::shared_ptr<Process>> CreateFirstProcess(
     std::string_view path, std::vector<std::string_view> &argv,
-    const std::vector<std::string_view> &envp, bool is_init) {
+    const std::vector<std::string_view> &envp, bool is_init, std::string cwd,
+    std::string fsroot, Thread **th_out) {
+  Status<std::shared_ptr<Inode>> ino =
+      LookupInode(FSRoot::GetGlobalRoot(), fsroot, true);
+  if (unlikely(!ino)) {
+    LOG(ERR) << "failed to find " << fsroot;
+    return MakeError(ino);
+  }
+  if (unlikely(!(*ino)->is_dir())) {
+    LOG(ERR) << "fsroot is not a directory: " << fsroot;
+    return MakeError(ENOTDIR);
+  }
+
+  FSRoot f(std::static_pointer_cast<IDir>(*ino),
+           std::static_pointer_cast<IDir>(*ino));
+  ino = LookupInode(f, cwd, true);
+  if (unlikely(!ino)) {
+    LOG(ERR) << "failed to find cwd" << cwd;
+    return MakeError(ino);
+  }
+  if (unlikely(!(*ino)->is_dir())) {
+    LOG(ERR) << "cwd is not a directory: " << cwd;
+    return MakeError(ENOTDIR);
+  }
+
+  f.SetCwd(std::static_pointer_cast<IDir>(std::move(*ino)));
+
   // Create the process object
   Status<std::pair<std::shared_ptr<Process>, Thread *>> tmp =
-      Process::CreateInit();
+      Process::CreateInit(f);
   if (!tmp) return MakeError(tmp);
   auto &[proc, th] = *tmp;
 
@@ -54,7 +80,10 @@ Status<std::shared_ptr<Process>> CreateFirstProcess(
 
   th->mark_enter_kernel();
   entry.MakeUnwinderSysret(*th, th->GetCaladanThread()->tf);
-  th->ThreadReady();
+  if (th_out)
+    *th_out = th;
+  else
+    th->ThreadReady();
   return std::move(proc);
 }
 

--- a/junction/run.cc
+++ b/junction/run.cc
@@ -32,7 +32,7 @@ Status<FSRoot> CreateFSRoot(const std::string &fsroot, const std::string &cwd) {
     root = std::static_pointer_cast<IDir>(std::move(*ino));
   }
 
-  FSRoot f(root, std::move(root));
+  FSRoot f(root, root);
 
   if (cwd.empty()) {
     f.SetCwd(FSRoot::GetGlobalRoot().get_cwd());

--- a/junction/run.cc
+++ b/junction/run.cc
@@ -14,38 +14,53 @@
 
 namespace junction {
 
+Status<FSRoot> CreateFSRoot(const std::string &fsroot, const std::string &cwd) {
+  std::shared_ptr<IDir> root;
+  if (fsroot.empty()) {
+    root = FSRoot::GetGlobalRoot().get_root();
+  } else {
+    Status<std::shared_ptr<Inode>> ino =
+        LookupInode(FSRoot::GetGlobalRoot(), fsroot, true);
+    if (unlikely(!ino)) {
+      LOG(ERR) << "failed to find " << fsroot;
+      return MakeError(ino);
+    }
+    if (unlikely(!(*ino)->is_dir())) {
+      LOG(ERR) << "fsroot is not a directory: " << fsroot;
+      return MakeError(ENOTDIR);
+    }
+    root = std::static_pointer_cast<IDir>(std::move(*ino));
+  }
+
+  FSRoot f(root, std::move(root));
+
+  if (cwd.empty()) {
+    f.SetCwd(FSRoot::GetGlobalRoot().get_cwd());
+  } else {
+    Status<std::shared_ptr<Inode>> ino = LookupInode(f, cwd, true);
+    if (unlikely(!ino)) {
+      LOG(ERR) << "failed to find cwd" << cwd;
+      return MakeError(ino);
+    }
+    if (unlikely(!(*ino)->is_dir())) {
+      LOG(ERR) << "cwd is not a directory: " << cwd;
+      return MakeError(ENOTDIR);
+    }
+    f.SetCwd(std::static_pointer_cast<IDir>(std::move(*ino)));
+  }
+  return f;
+}
+
 Status<std::shared_ptr<Process>> CreateFirstProcess(
     std::string_view path, std::vector<std::string_view> &argv,
     const std::vector<std::string_view> &envp, bool is_init, std::string cwd,
     std::string fsroot, Thread **th_out) {
-  Status<std::shared_ptr<Inode>> ino =
-      LookupInode(FSRoot::GetGlobalRoot(), fsroot, true);
-  if (unlikely(!ino)) {
-    LOG(ERR) << "failed to find " << fsroot;
-    return MakeError(ino);
-  }
-  if (unlikely(!(*ino)->is_dir())) {
-    LOG(ERR) << "fsroot is not a directory: " << fsroot;
-    return MakeError(ENOTDIR);
-  }
-
-  FSRoot f(std::static_pointer_cast<IDir>(*ino),
-           std::static_pointer_cast<IDir>(*ino));
-  ino = LookupInode(f, cwd, true);
-  if (unlikely(!ino)) {
-    LOG(ERR) << "failed to find cwd" << cwd;
-    return MakeError(ino);
-  }
-  if (unlikely(!(*ino)->is_dir())) {
-    LOG(ERR) << "cwd is not a directory: " << cwd;
-    return MakeError(ENOTDIR);
-  }
-
-  f.SetCwd(std::static_pointer_cast<IDir>(std::move(*ino)));
+  Status<FSRoot> f = CreateFSRoot(fsroot, cwd);
+  if (!f) return MakeError(f);
 
   // Create the process object
   Status<std::pair<std::shared_ptr<Process>, Thread *>> tmp =
-      Process::CreateInit(f);
+      Process::CreateInit(*f);
   if (!tmp) return MakeError(tmp);
   auto &[proc, th] = *tmp;
 

--- a/junction/run.h
+++ b/junction/run.h
@@ -9,7 +9,8 @@ namespace junction {
 
 Status<std::shared_ptr<Process>> CreateFirstProcess(
     std::string_view path, std::vector<std::string_view> &argv,
-    const std::vector<std::string_view> &envp, bool is_init = true);
+    const std::vector<std::string_view> &envp, bool is_init = true,
+    std::string cwd = "/", std::string root = "/", Thread **th_out = nullptr);
 
 std::pair<std::vector<std::string>, std::vector<std::string_view>> BuildEnvp();
 }  // namespace junction

--- a/junction/run.h
+++ b/junction/run.h
@@ -10,7 +10,7 @@ namespace junction {
 Status<std::shared_ptr<Process>> CreateFirstProcess(
     std::string_view path, std::vector<std::string_view> &argv,
     const std::vector<std::string_view> &envp, bool is_init = true,
-    std::string cwd = "/", std::string root = "/", Thread **th_out = nullptr);
+    std::string cwd = "", std::string root = "", Thread **th_out = nullptr);
 
 std::pair<std::vector<std::string>, std::vector<std::string_view>> BuildEnvp();
 }  // namespace junction

--- a/junction/shim/backend/init.cc
+++ b/junction/shim/backend/init.cc
@@ -8,6 +8,8 @@
 namespace junction {
 
 Status<void> ShimJmpInit() {
+  if (sizeof(shim_jmptbl) == 0) return {};
+
   Status<void> ret =
       KernelMMapFixed(reinterpret_cast<void *>(SHIMCALL_JMPTBL_LOC),
                       sizeof(shim_jmptbl), PROT_READ | PROT_WRITE, 0);

--- a/junction/snapshot/pod.h
+++ b/junction/snapshot/pod.h
@@ -44,7 +44,7 @@ void serialize(Archive &archive, siginfo_t &s) {
 
 template <class Archive>
 void serialize(Archive &archive, netaddr &n) {
-  archive(n.ip, n.port);
+  archive(cereal::binary_data(reinterpret_cast<uint8_t *>(&n), sizeof(n)));
 }
 
 template <class Archive>

--- a/junction/snapshot/snapshot.cc
+++ b/junction/snapshot/snapshot.cc
@@ -75,7 +75,7 @@ Status<void> RestoreVMAProtections(MemoryMap &mm) {
 }
 
 Status<void> TakeSnapshot(Process *p) {
-  const std::string &prefix = GetCfg().get_snapshot_prefix();
+  const std::string prefix = GetCfg().GetArg("snapshot-prefix");
   if (GetCfg().jif())
     return SnapshotProcToJIF(p, prefix + ".jm", prefix + ".jif");
   return SnapshotProcToELF(p, prefix + ".metadata", prefix + ".elf");

--- a/junction/snapshot/snapshot_jif.cc
+++ b/junction/snapshot/snapshot_jif.cc
@@ -139,7 +139,7 @@ Status<std::tuple<jif_data, IOVAccumulator>> GetJifVmaData(
 
   for (const VMArea &vma : vmas) {
     if (vma.type == VMType::kFile && vma.file->SnapshotShareable()) {
-      const std::string &name = vma.file->get_filename();
+      const std::string &name = vma.file->get_filename(FSRoot::GetGlobalRoot());
       assert(name.size());
       jif.AddPhdr(iovs, vma.prot, vma.start, vma.DataLength(), vma.Length(),
                   vma.offset, name);

--- a/junction/syscall/CMakeLists.txt
+++ b/junction/syscall/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(syscall
   syscall.cc
   seccomp.cc
   strace.cc
+  strace_maps.cc
   syscall_tbl.cc
   entry.S
   vdso/vdso_inc.S

--- a/junction/syscall/entry.S
+++ b/junction/syscall/entry.S
@@ -486,6 +486,10 @@ __kframe_unwind_uiret:
 	// and (B) ensure correct alignment for the next call
 	leaq    (JUNCTION_STACK_SIZE - JUNCTION_STACK_RESERVED - 16)(%r11), %r11;
 
+	// We start storing the trapframe on the stack in a "redzone" before we
+	// actually adjust the stack pointer. Other sites that place data on the
+	// bottom of the syscall stack must account for this redzone.
+
 	// save return stack pointer to new stack
 	leaq    8(%rsp), %r10;
 	movq    %r10, (%r11);

--- a/junction/syscall/strace.cc
+++ b/junction/syscall/strace.cc
@@ -207,6 +207,11 @@ const std::map<int, std::string> fcntls{
 #define PR_GET_MDWE 66
 #endif
 
+const std::map<int, std::string> poll_flags{
+    VAL(POLLIN),     VAL(POLLPRI),    VAL(POLLOUT),    VAL(POLLRDHUP),
+    VAL(POLLERR),    VAL(POLLHUP),    VAL(POLLNVAL),   VAL(POLLRDNORM),
+    VAL(POLLRDBAND), VAL(POLLWRNORM), VAL(POLLWRBAND), VAL(POLLMSG)};
+
 const std::map<int, std::string> prctl_ops{
     VAL(PR_CAP_AMBIENT),
     VAL(PR_CAPBSET_READ),
@@ -335,13 +340,41 @@ void PrintArg(const sigset_t *sigmask, rt::Logger &ss) {
   ss << "}";
 }
 
-void PrintValMap(const std::map<int, std::string> &map, int val,
-                 rt::Logger &ss) {
+void PrintIoctlReq(unsigned int request, rt::Logger &ss) {
+  unsigned int dir = _IOC_DIR(request);
+  unsigned int type = _IOC_TYPE(request);
+  unsigned int nr = _IOC_NR(request);
+  unsigned int size = _IOC_SIZE(request);
+
+  ss << "_IOC(";
+
+  bool printed = false;
+  if (dir & _IOC_READ) {
+    ss << "_IOC_READ";
+    printed = true;
+  }
+  if (dir & _IOC_WRITE) {
+    if (printed) ss << "|";
+    ss << "_IOC_WRITE";
+    printed = true;
+  }
+  if (!printed) {
+    ss << "0";
+  }
+
+  ss << ", 0x" << std::hex << type << ", 0x" << std::hex << nr << ", 0x"
+     << std::hex << size << ")";
+}
+
+bool PrintValMap(const std::map<int, std::string> &map, int val, rt::Logger &ss,
+                 bool print_on_miss = true) {
   auto it = map.find(val);
-  if (it != map.end())
+  if (it != map.end()) {
     ss << it->second;
-  else
-    ss << val;
+    return true;
+  }
+  if (print_on_miss) ss << val;
+  return false;
 }
 
 void PrintArg(const cap_user_data_t datap, rt::Logger &ss) {
@@ -442,6 +475,25 @@ bool PrintFlagArr(const std::map<int, std::string> &map, int flags,
   return done_one;
 }
 
+bool PrintArg(struct pollfd el, rt::Logger &ss, bool first) {
+  if (!first) ss << ", ";
+  ss << "{fd=" << el.fd << ", events=";
+  PrintFlagArr(poll_flags, el.events, ss);
+  ss << ", revents=";
+  PrintFlagArr(poll_flags, el.revents, ss);
+  ss << "}";
+  return true;
+}
+
+bool PrintArg(const struct epoll_event el, rt::Logger &ss, bool first) {
+  if (!el.events) return false;
+  if (!first) ss << ", ";
+  ss << "{events=";
+  PrintFlagArr(poll_flags, el.events, ss);
+  ss << ", data=" << el.data.u64 << "}";
+  return true;
+}
+
 void PrintArg(int option, WaitOptions, rt::Logger &ss) {
   const static std::map<int, std::string> flags = {
       VAL(WEXITED), VAL(WSTOPPED),  VAL(WCONTINUED), VAL(WNOHANG),
@@ -483,7 +535,7 @@ void PrintArg(unsigned int op, FcntlOp, rt::Logger &ss) {
 }
 
 void PrintArg(unsigned int op, IoctlOp, rt::Logger &ss) {
-  PrintValMap(ioctls, op, ss);
+  if (!PrintValMap(ioctls, op, ss, false)) PrintIoctlReq(op, ss);
 }
 
 void PrintArg(int flags, MMapFlag, rt::Logger &ss) {

--- a/junction/syscall/strace.cc
+++ b/junction/syscall/strace.cc
@@ -256,6 +256,64 @@ const std::map<int, std::string> at_flags{
 #define PR_GET_MDWE 66
 #endif
 
+void PrintEscapedString(std::span<const char> str, rt::Logger &ss) {
+  if (!str.size()) {
+    ss << "\"\"";
+    return;
+  }
+
+  ss << "\"";
+  size_t len = 0;
+  const char *pos = str.data();
+  while (len < std::min(str.size(), kMaxEscapedStringLen)) {
+    unsigned char c = *pos++;
+    if (c >= 32 && c <= 126 && c != '\\' && c != '"') {
+      // Printable ASCII characters (except \ and ")
+      ss << c;
+    } else {
+      // Escape special characters
+      switch (c) {
+        case '\\':
+          ss << "\\\\";
+          break;
+        case '"':
+          ss << "\\\"";
+          break;
+        case '\n':
+          ss << "\\n";
+          break;
+        case '\r':
+          ss << "\\r";
+          break;
+        case '\t':
+          ss << "\\t";
+          break;
+        case '\f':
+          ss << "\\f";
+          break;
+        case '\v':
+          ss << "\\v";
+          break;
+        case '\b':
+          ss << "\\b";
+          break;
+        case '\a':
+          ss << "\\a";
+          break;
+        default:
+          // Print non-printable chars as octal
+          ss << '\\' << std::oct << std::setfill('0') << std::setw(3)
+             << static_cast<unsigned int>(c) << std::dec;
+      }
+    }
+    len++;
+  }
+  if (*pos) {
+    ss << "...";
+  }
+  ss << "\"";
+}
+
 const std::map<int, std::string> poll_flags{
     VAL(POLLIN),     VAL(POLLPRI),    VAL(POLLOUT),    VAL(POLLRDHUP),
     VAL(POLLERR),    VAL(POLLHUP),    VAL(POLLNVAL),   VAL(POLLRDNORM),
@@ -486,13 +544,18 @@ void PrintArg(int op, SocketType, rt::Logger &ss,
   if (op & SOCK_CLOEXEC) ss << "|SOCK_CLOEXEC";
 }
 
-void PrintArg(const struct msghdr &msg, rt::Logger &ss) {
+void PrintArg(const struct msghdr *msg, rt::Logger &ss, SyscallCtx &ctx) {
   ss << "{msg_name=";
-  PrintArg(reinterpret_cast<const struct sockaddr *>(msg.msg_name), ss);
-  ss << ", msg_namelen=" << msg.msg_namelen << ", msg_iov=" << msg.msg_iov
-     << ", msg_iovlen=" << msg.msg_iovlen << ", msg_control=" << msg.msg_control
-     << ", msg_controllen=" << msg.msg_controllen
-     << ", msg_flags=" << msg.msg_flags << "}";
+  PrintArg(reinterpret_cast<const struct sockaddr *>(msg->msg_name), ss);
+  ss << ", msg_namelen=" << msg->msg_namelen << ", msg_iov=";
+
+  std::span<const iovec> span(reinterpret_cast<const iovec *>(msg->msg_iov),
+                              msg->msg_iovlen);
+  PrintArgSpan(span, ss, ctx);
+  ss << ", msg_iovlen=" << msg->msg_iovlen
+     << ", msg_control=" << msg->msg_control
+     << ", msg_controllen=" << msg->msg_controllen
+     << ", msg_flags=" << msg->msg_flags << "}";
 }
 
 void PrintArg(int advice, MAdviseHint, rt::Logger &ss,
@@ -549,22 +612,20 @@ bool PrintFlagArr(const std::map<int, std::string> &map, int flags,
   return done_one;
 }
 
-bool PrintArg(struct pollfd el, rt::Logger &ss, bool first) {
-  if (!first) ss << ", ";
-  ss << "{fd=" << el.fd << ", events=";
-  PrintFlagArr(poll_flags, el.events, ss);
+bool PrintArg(const struct pollfd *el, rt::Logger &ss, SyscallCtx &ctx) {
+  ss << "{fd=" << el->fd << ", events=";
+  PrintFlagArr(poll_flags, el->events, ss);
   ss << ", revents=";
-  PrintFlagArr(poll_flags, el.revents, ss);
+  PrintFlagArr(poll_flags, el->revents, ss);
   ss << "}";
   return true;
 }
 
-bool PrintArg(const struct epoll_event el, rt::Logger &ss, bool first) {
-  if (!el.events) return false;
-  if (!first) ss << ", ";
+bool PrintArg(const struct epoll_event *el, rt::Logger &ss, SyscallCtx &ctx) {
+  if (!el->events) return false;
   ss << "{events=";
-  PrintFlagArr(poll_flags, el.events, ss);
-  ss << ", data=" << el.data.u64 << "}";
+  PrintFlagArr(poll_flags, el->events, ss);
+  ss << ", data=" << el->data.u64 << "}";
   return true;
 }
 

--- a/junction/syscall/strace.cc
+++ b/junction/syscall/strace.cc
@@ -88,9 +88,7 @@ void PrintEscapedString(std::span<const char> str, rt::Logger &ss) {
     }
     len++;
   }
-  if (*pos) {
-    ss << "...";
-  }
+  if (*pos) { ss << "..."; }
   ss << "\"";
 }
 
@@ -141,9 +139,7 @@ void PrintIoctlReq(unsigned int request, rt::Logger &ss) {
     ss << "_IOC_WRITE";
     printed = true;
   }
-  if (!printed) {
-    ss << "0";
-  }
+  if (!printed) { ss << "0"; }
 
   ss << ", 0x" << std::hex << type << ", 0x" << std::hex << nr << ", 0x"
      << std::hex << size << ")";

--- a/junction/syscall/strace.cc
+++ b/junction/syscall/strace.cc
@@ -58,17 +58,25 @@ const std::map<int, std::string> mmap_flags{
 };
 
 const std::map<int, std::string> open_flags{
-    {O_APPEND, "O_APPEND"},       {O_ASYNC, "O_ASYNC"},
-    {O_CLOEXEC, "O_CLOEXEC"},     {O_CREAT, "O_CREAT"},
-    {O_DIRECT, "O_DIRECT"},       {O_DIRECTORY, "O_DIRECTORY"},
-    {O_DSYNC, "O_DSYNC"},         {O_EXCL, "O_EXCL"},
-    {O_LARGEFILE, "O_LARGEFILE"}, {O_NOATIME, "O_NOATIME"},
-    {O_NOCTTY, "O_NOCTTY"},       {O_NOFOLLOW, "O_NOFOLLOW"},
-    {O_NONBLOCK, "O_NONBLOCK"},   {O_PATH, "O_PATH"},
-    {O_SYNC, "O_SYNC"},           {O_TMPFILE, "O_TMPFILE"},
-    {O_TRUNC, "O_TRUNC"},         {O_WRONLY, "O_WRONLY"},
+    {O_APPEND, "O_APPEND"},
+    {O_ASYNC, "O_ASYNC"},
+    {O_CLOEXEC, "O_CLOEXEC"},
+    {O_CREAT, "O_CREAT"},
+    {O_DIRECT, "O_DIRECT"},
+    {O_DIRECTORY, "O_DIRECTORY"},
+    {O_DSYNC, "O_DSYNC"},
+    {O_EXCL, "O_EXCL"},
+    {O_LARGEFILE, "O_LARGEFILE"},
+    {O_NOATIME, "O_NOATIME"},
+    {O_NOCTTY, "O_NOCTTY"},
+    {O_NOFOLLOW, "O_NOFOLLOW"},
+    {O_NONBLOCK, "O_NONBLOCK"},
+    {O_PATH, "O_PATH"},
+    {O_SYNC, "O_SYNC"},
+    {O_TRUNC, "O_TRUNC"},
+    {O_WRONLY, "O_WRONLY"},
     {O_RDWR, "O_RDWR"},
-};
+    {(O_TMPFILE & ~O_DIRECTORY), "O_TMPFILE"}};
 
 const std::map<int, std::string> madvise_hints{
     {MADV_NORMAL, "MADV_NORMAL"},
@@ -140,6 +148,13 @@ const std::map<int, std::string> futex_flags{
     {FUTEX_CMP_REQUEUE_PI, "FUTEX_CMP_REQUEUE_PI"},
     {FUTEX_WAIT_REQUEUE_PI, "FUTEX_WAIT_REQUEUE_PI"},
 };
+
+const std::set<int> futex_ops_with_val2{FUTEX_CMP_REQUEUE, FUTEX_WAKE_OP,
+                                        FUTEX_CMP_REQUEUE_PI};
+
+const std::set<int> futex_ops_with_timeout{FUTEX_WAIT, FUTEX_WAIT_BITSET,
+                                           FUTEX_LOCK_PI, FUTEX_LOCK_PI2,
+                                           FUTEX_WAIT_REQUEUE_PI};
 
 const std::map<int, std::string> ioctls{
     VAL(TCGETS), VAL(TCSETS), VAL(TCSETSW), VAL(TCSETSF), VAL(TCGETA),
@@ -564,6 +579,14 @@ void PrintArg(int op, FutexOp, rt::Logger &ss,
 
   if (op & FUTEX_PRIVATE_FLAG) ss << "|FUTEX_PRIVATE";
   if (op & FUTEX_CLOCK_REALTIME) ss << "|FUTEX_CLOCK_REALTIME";
+
+  if (futex_ops_with_val2.count(cmd)) {
+    ctx.arg_strs[3].emplace() << (uint32_t)std::get<3>(ctx.args);
+  } else if (futex_ops_with_timeout.count(cmd)) {
+    const struct timespec *t =
+        reinterpret_cast<const struct timespec *>(std::get<3>(ctx.args));
+    PrintArg(t, ctx.arg_strs[3].emplace());
+  }
 }
 
 void PrintArg(int op, SigProcMaskOp, rt::Logger &ss,
@@ -600,6 +623,165 @@ void PrintArg(int *fds, FDPair *, rt::Logger &ss,
   ss << "[" << fds[0] << ", " << fds[1] << "]";
 }
 
+const std::map<int, std::string> sockopt_levels = {
+    VAL(SOL_SOCKET),   VAL(IPPROTO_IP),  VAL(IPPROTO_TCP), VAL(IPPROTO_UDP),
+    VAL(IPPROTO_IPV6), VAL(IPPROTO_RAW), VAL(SOL_NETLINK),
+};
+
+const std::map<int, std::string> sock_options = {
+    VAL(SO_DEBUG),
+    VAL(SO_REUSEADDR),
+    VAL(SO_TYPE),
+    VAL(SO_ERROR),
+    VAL(SO_DONTROUTE),
+    VAL(SO_BROADCAST),
+    VAL(SO_SNDBUF),
+    VAL(SO_RCVBUF),
+    VAL(SO_KEEPALIVE),
+    VAL(SO_OOBINLINE),
+    VAL(SO_NO_CHECK),
+    VAL(SO_PRIORITY),
+    VAL(SO_LINGER),
+    VAL(SO_BSDCOMPAT),
+    VAL(SO_REUSEPORT),
+    VAL(SO_PASSCRED),
+    VAL(SO_PEERCRED),
+    VAL(SO_RCVLOWAT),
+    VAL(SO_SNDLOWAT),
+    VAL(SO_RCVTIMEO),
+    VAL(SO_SNDTIMEO),
+    VAL(SO_SECURITY_AUTHENTICATION),
+    VAL(SO_SECURITY_ENCRYPTION_TRANSPORT),
+    VAL(SO_SECURITY_ENCRYPTION_NETWORK),
+    VAL(SO_BINDTODEVICE),
+    VAL(SO_DETACH_FILTER),
+    VAL(SO_PEERNAME),
+    VAL(SO_TIMESTAMP_OLD),
+    VAL(SO_ACCEPTCONN),
+    VAL(SO_PEERSEC),
+    VAL(SO_SNDBUFFORCE),
+    VAL(SO_RCVBUFFORCE),
+    VAL(SO_PASSSEC),
+    VAL(SO_TIMESTAMPNS_OLD),
+    VAL(SO_MARK),
+    VAL(SO_TIMESTAMPING_OLD),
+    VAL(SO_PROTOCOL),
+    VAL(SO_DOMAIN),
+    VAL(SO_RXQ_OVFL),
+    VAL(SO_WIFI_STATUS),
+    VAL(SO_PEEK_OFF),
+    VAL(SO_NOFCS),
+    VAL(SO_LOCK_FILTER),
+    VAL(SO_SELECT_ERR_QUEUE),
+    VAL(SO_BUSY_POLL),
+    VAL(SO_MAX_PACING_RATE),
+    VAL(SO_BPF_EXTENSIONS),
+    VAL(SO_INCOMING_CPU),
+    VAL(SO_ATTACH_BPF),
+    VAL(SO_ATTACH_REUSEPORT_CBPF),
+    VAL(SO_ATTACH_REUSEPORT_EBPF),
+    VAL(SO_CNX_ADVICE),
+    VAL(SO_MEMINFO),
+    VAL(SO_INCOMING_NAPI_ID),
+    VAL(SO_COOKIE),
+    VAL(SO_PEERGROUPS),
+    VAL(SO_ZEROCOPY),
+    VAL(SO_TXTIME),
+    VAL(SO_BINDTOIFINDEX),
+    VAL(SO_TIMESTAMP_NEW),
+    VAL(SO_TIMESTAMPNS_NEW),
+    VAL(SO_TIMESTAMPING_NEW),
+    VAL(SO_RCVTIMEO_NEW),
+    VAL(SO_SNDTIMEO_NEW),
+    VAL(SO_DETACH_REUSEPORT_BPF),
+    VAL(SO_PREFER_BUSY_POLL),
+    VAL(SO_BUSY_POLL_BUDGET),
+    VAL(SO_NETNS_COOKIE),
+    VAL(SO_BUF_LOCK),
+    VAL(SO_RESERVE_MEM),
+    VAL(SO_TXREHASH),
+    VAL(SO_RCVMARK),
+    VAL(SO_PASSPIDFD),
+    VAL(SO_PEERPIDFD),
+    // VAL(SO_RCVPRIORITY),
+    // VAL(SO_PASSRIGHTS),
+    // VAL(SO_INQ),
+};
+
+const std::set<int> intlike_sockopts = {
+    SO_DEBUG,
+    SO_REUSEADDR,
+    SO_DONTROUTE,
+    SO_BROADCAST,
+    SO_SNDBUF,
+    SO_RCVBUF,
+    SO_KEEPALIVE,
+    SO_OOBINLINE,
+    SO_NO_CHECK,
+    SO_PRIORITY,
+    SO_BSDCOMPAT,
+    SO_REUSEPORT,
+    SO_PASSCRED,
+    SO_RCVLOWAT,
+    SO_SNDLOWAT,
+    SO_DETACH_FILTER,
+    SO_TIMESTAMP_OLD,
+    SO_ACCEPTCONN,
+    SO_SNDBUFFORCE,
+    SO_RCVBUFFORCE,
+    SO_PASSSEC,
+    SO_TIMESTAMPNS_OLD,
+    SO_MARK,
+    SO_TIMESTAMPING_OLD,
+    SO_RXQ_OVFL,
+    SO_WIFI_STATUS,
+    SO_PEEK_OFF,
+    SO_NOFCS,
+    SO_LOCK_FILTER,
+    SO_SELECT_ERR_QUEUE,
+    SO_BUSY_POLL,
+    SO_INCOMING_CPU,
+    SO_CNX_ADVICE,
+    SO_INCOMING_NAPI_ID,
+    SO_ZEROCOPY,
+    SO_TIMESTAMP_NEW,
+    SO_TIMESTAMPNS_NEW,
+    SO_TIMESTAMPING_NEW,
+    SO_DETACH_REUSEPORT_BPF,
+    SO_PREFER_BUSY_POLL,
+    SO_BUSY_POLL_BUDGET,
+    SO_RESERVE_MEM,
+    SO_RCVMARK,
+    SO_PASSPIDFD,
+    // SO_RCVPRIORITY,
+    // SO_PASSRIGHTS,
+    // SO_INQ
+};
+
+void PrintArg(int level, SockoptLevel, rt::Logger &ss, SyscallCtx &ctx) {
+  PrintValMap(sockopt_levels, level, ss);
+  int sockopt = std::get<2>(ctx.args);
+  switch (level) {
+    case SOL_SOCKET: {
+      auto it = sock_options.find(sockopt);
+      if (it == sock_options.end()) return;
+      ctx.arg_strs[2].emplace(it->second);
+      if (intlike_sockopts.count(sockopt)) {
+        ctx.arg_strs[3].emplace()
+            << "[" << *reinterpret_cast<int *>(std::get<3>(ctx.args)) << "]";
+        ctx.arg_strs[4].emplace();
+      } else if (sockopt == SO_RCVTIMEO || sockopt == SO_SNDTIMEO) {
+        struct timeval tv =
+            *reinterpret_cast<struct timeval *>(std::get<3>(ctx.args));
+        PrintArg(tv, ctx.arg_strs[3].emplace());
+        ctx.arg_strs[4].emplace();
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
 }  // namespace strace
 
 void LogSignal(const siginfo_t &info) {

--- a/junction/syscall/strace.cc
+++ b/junction/syscall/strace.cc
@@ -351,7 +351,7 @@ const char *sigmap[] = {
 const std::map<int, std::string> sigprocmask_how{
     VAL(SIG_BLOCK), VAL(SIG_UNBLOCK), VAL(SIG_SETMASK)};
 
-void PrintArg(const sigset_t *sigmask, rt::Logger &ss) {
+void PrintSigset(const sigset_t *sigmask, rt::Logger &ss) {
   if (!sigmask) {
     ss << "NULL";
     return;
@@ -411,7 +411,7 @@ bool PrintValMap(const std::map<int, std::string> &map, int val, rt::Logger &ss,
   return false;
 }
 
-void PrintArg(const cap_user_data_t datap, rt::Logger &ss) {
+void PrintUserCap(const cap_user_data_t datap, rt::Logger &ss) {
   if (!datap) {
     ss << "NULL";
     return;
@@ -458,40 +458,46 @@ void PrintArg(const struct sockaddr *addr, rt::Logger &ss) {
   ss << ip << ":" << ntoh16(sin->sin_port);
 }
 
-void PrintArg(int op, SocketDomain, rt::Logger &ss) {
+void PrintArg(int op, SocketDomain, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   PrintValMap(sock_domains, op, ss);
 }
 
-void PrintArg(int op, SocketType, rt::Logger &ss) {
+void PrintArg(int op, SocketType, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   int type = op & ~(SOCK_NONBLOCK | SOCK_CLOEXEC);
   PrintValMap(sock_types, type, ss);
   if (op & SOCK_NONBLOCK) ss << "|SOCK_NONBLOCK";
   if (op & SOCK_CLOEXEC) ss << "|SOCK_CLOEXEC";
 }
 
-void PrintArg(int advice, MAdviseHint, rt::Logger &ss) {
+void PrintArg(int advice, MAdviseHint, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   PrintValMap(madvise_hints, advice, ss);
 }
 
-void PrintArg(int signo, SignalNumber, rt::Logger &ss) {
+void PrintArg(int signo, SignalNumber, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   if (static_cast<size_t>(signo) <= ARRAY_SIZE(sigmap))
     ss << sigmap[signo - 1];
   else
     ss << "SIGRT" << signo;
 }
 
-void PrintArg(int op, EpollOp, rt::Logger &ss) {
+void PrintArg(int op, EpollOp, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   PrintValMap(epoll_ctl_ops, op, ss);
 }
 
-void PrintArg(const char *arg, PathName *, rt::Logger &ss) {
+void PrintArg(const char *arg, PathName *, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   if (!arg)
     ss << "<null>";
   else
     ss << "\"" << arg << "\"";
 }
 
-void PrintArg(int fd, AtFD, rt::Logger &ss) {
+void PrintArg(int fd, AtFD, rt::Logger &ss, [[maybe_unused]] SyscallCtx &ctx) {
   if (fd == AT_FDCWD)
     ss << "AT_FDCWD";
   else
@@ -542,7 +548,8 @@ const std::map<int, std::string> wait_flags = {
     VAL(WNOWAIT), VAL(WUNTRACED), VAL(WCONTINUED),
 };
 
-void PrintArg(int prot, ProtFlag, rt::Logger &ss) {
+void PrintArg(int prot, ProtFlag, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   if (prot == PROT_NONE) {
     ss << "PROT_NONE";
     return;
@@ -550,7 +557,8 @@ void PrintArg(int prot, ProtFlag, rt::Logger &ss) {
   PrintFlagArr(protection_flags, prot, ss);
 }
 
-void PrintArg(int op, FutexOp, rt::Logger &ss) {
+void PrintArg(int op, FutexOp, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   int cmd = op & FUTEX_CMD_MASK;
   PrintValMap(futex_flags, cmd, ss);
 
@@ -558,23 +566,28 @@ void PrintArg(int op, FutexOp, rt::Logger &ss) {
   if (op & FUTEX_CLOCK_REALTIME) ss << "|FUTEX_CLOCK_REALTIME";
 }
 
-void PrintArg(int op, SigProcMaskOp, rt::Logger &ss) {
+void PrintArg(int op, SigProcMaskOp, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   PrintValMap(sigprocmask_how, op, ss);
 }
 
-void PrintArg(long op, PrctlOp, rt::Logger &ss) {
+void PrintArg(long op, PrctlOp, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   PrintValMap(prctl_ops, op, ss);
 }
 
-void PrintArg(unsigned int op, FcntlOp, rt::Logger &ss) {
+void PrintArg(unsigned int op, FcntlOp, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   PrintValMap(fcntls, op, ss);
 }
 
-void PrintArg(unsigned int op, IoctlOp, rt::Logger &ss) {
+void PrintArg(unsigned int op, IoctlOp, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   if (!PrintValMap(ioctls, op, ss, false)) PrintIoctlReq(op, ss);
 }
 
-void PrintArg(int flags, OpenFlag, rt::Logger &ss) {
+void PrintArg(int flags, OpenFlag, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   bool done_one = PrintFlagArr(open_flags, flags, ss);
   if ((flags & (O_WRONLY | O_RDWR)) == 0) {
     if (done_one) ss << "|";
@@ -582,7 +595,8 @@ void PrintArg(int flags, OpenFlag, rt::Logger &ss) {
   }
 }
 
-void PrintArg(int *fds, FDPair *, rt::Logger &ss) {
+void PrintArg(int *fds, FDPair *, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
   ss << "[" << fds[0] << ", " << fds[1] << "]";
 }
 

--- a/junction/syscall/strace.cc
+++ b/junction/syscall/strace.cc
@@ -1,5 +1,7 @@
 #include "junction/syscall/strace.h"
 
+#include "junction/syscall/strace_maps.h"
+
 extern "C" {
 #include <linux/futex.h>
 #include <linux/ioctl.h>
@@ -17,231 +19,9 @@ extern "C" {
 #include "junction/bindings/log.h"
 #include "junction/net/socket.h"
 
-#ifndef MADV_COLLAPSE
-#define MADV_COLLAPSE 25 /* Synchronous hugepage collapse */
-#endif
-
-#ifndef CLONE_CLEAR_SIGHAND
-#define CLONE_CLEAR_SIGHAND 0x100000000ULL
-#endif
-
-#ifndef CLONE_INTO_CGROUP
-#define CLONE_INTO_CGROUP 0x200000000ULL
-#endif
-
 namespace junction {
 
 namespace strace {
-
-#define VAL(x) \
-  { x, #x }
-
-const std::map<int, std::string> protection_flags{
-    VAL(PROT_READ),
-    {PROT_WRITE, "PROT_WRITE"},
-    {PROT_EXEC, "PROT_EXEC"},
-};
-
-const std::map<int, std::string> mmap_flags{
-    {MAP_SHARED, "MAP_SHARED"},
-    {MAP_PRIVATE, "MAP_PRIVATE"},
-    {MAP_ANONYMOUS, "MAP_ANONYMOUS"},
-    {MAP_FIXED, "MAP_FIXED"},
-    {MAP_FIXED_NOREPLACE, "MAP_FIXED_NOREPLACE"},
-    {MAP_GROWSDOWN, "MAP_GROWSDOWN"},
-    {MAP_HUGETLB, "MAP_HUGETLB"},
-    {MAP_LOCKED, "MAP_LOCKED"},
-    {MAP_NONBLOCK, "MAP_NONBLOCK"},
-    {MAP_NORESERVE, "MAP_NORESERVE"},
-    {MAP_POPULATE, "MAP_POPULATE"},
-    {MAP_STACK, "MAP_STACK"},
-};
-
-const std::map<int, std::string> open_flags{
-    {O_APPEND, "O_APPEND"},
-    {O_ASYNC, "O_ASYNC"},
-    {O_CLOEXEC, "O_CLOEXEC"},
-    {O_CREAT, "O_CREAT"},
-    {O_DIRECT, "O_DIRECT"},
-    {O_DIRECTORY, "O_DIRECTORY"},
-    {O_DSYNC, "O_DSYNC"},
-    {O_EXCL, "O_EXCL"},
-    {O_LARGEFILE, "O_LARGEFILE"},
-    {O_NOATIME, "O_NOATIME"},
-    {O_NOCTTY, "O_NOCTTY"},
-    {O_NOFOLLOW, "O_NOFOLLOW"},
-    {O_NONBLOCK, "O_NONBLOCK"},
-    {O_PATH, "O_PATH"},
-    {O_SYNC, "O_SYNC"},
-    {O_TRUNC, "O_TRUNC"},
-    {O_WRONLY, "O_WRONLY"},
-    {O_RDWR, "O_RDWR"},
-    {(O_TMPFILE & ~O_DIRECTORY), "O_TMPFILE"}};
-
-const std::map<int, std::string> madvise_hints{
-    {MADV_NORMAL, "MADV_NORMAL"},
-    {MADV_DONTNEED, "MADV_DONTNEED"},
-    {MADV_RANDOM, "MADV_RANDOM"},
-    {MADV_REMOVE, "MADV_REMOVE"},
-    {MADV_SEQUENTIAL, "MADV_SEQUENTIAL"},
-    {MADV_DONTFORK, "MADV_DONTFORK"},
-    {MADV_WILLNEED, "MADV_WILLNEED"},
-    {MADV_DOFORK, "MADV_DOFORK"},
-    {MADV_HUGEPAGE, "MADV_HUGEPAGE"},
-    {MADV_HWPOISON, "MADV_HWPOISON"},
-    {MADV_NOHUGEPAGE, "MADV_NOHUGEPAGE"},
-    {MADV_MERGEABLE, "MADV_MERGEABLE"},
-    {MADV_COLLAPSE, "MADV_COLLAPSE"},
-    {MADV_UNMERGEABLE, "MADV_UNMERGEABLE"},
-    {MADV_DONTDUMP, "MADV_DONTDUMP"},
-    {MADV_DODUMP, "MADV_DODUMP"},
-    {MADV_FREE, "MADV_FREE"},
-    {MADV_WIPEONFORK, "MADV_WIPEONFORK"},
-    {MADV_COLD, "MADV_COLD"},
-    {MADV_PAGEOUT, "MADV_PAGEOUT"},
-    {MADV_POPULATE_READ, "MADV_POPULATE_READ"},
-    {MADV_POPULATE_WRITE, "MADV_POPULATE_WRITE"},
-};
-
-const std::map<int, std::string> clone_flags{
-    {CLONE_CHILD_CLEARTID, "CLONE_CHILD_CLEARTID"},
-    {CLONE_CHILD_SETTID, "CLONE_CHILD_SETTID"},
-    {CLONE_CLEAR_SIGHAND, "CLONE_CLEAR_SIGHAND"},
-    {CLONE_DETACHED, "CLONE_DETACHED"},
-    {CLONE_FILES, "CLONE_FILES"},
-    {CLONE_FS, "CLONE_FS"},
-    {CLONE_INTO_CGROUP, "CLONE_INTO_CGROUP"},
-    {CLONE_IO, "CLONE_IO"},
-    {CLONE_NEWCGROUP, "CLONE_NEWCGROUP"},
-    {CLONE_NEWIPC, "CLONE_NEWIPC"},
-    {CLONE_NEWNET, "CLONE_NEWNET"},
-    {CLONE_NEWNS, "CLONE_NEWNS"},
-    {CLONE_NEWPID, "CLONE_NEWPID"},
-    {CLONE_NEWUSER, "CLONE_NEWUSER"},
-    {CLONE_NEWUTS, "CLONE_NEWUTS"},
-    {CLONE_PARENT, "CLONE_PARENT"},
-    {CLONE_PARENT_SETTID, "CLONE_PARENT_SETTID"},
-    {CLONE_PIDFD, "CLONE_PIDFD"},
-    {CLONE_PTRACE, "CLONE_PTRACE"},
-    {CLONE_SETTLS, "CLONE_SETTLS"},
-    {CLONE_SIGHAND, "CLONE_SIGHAND"},
-    {CLONE_SYSVSEM, "CLONE_SYSVSEM"},
-    {CLONE_THREAD, "CLONE_THREAD"},
-    {CLONE_UNTRACED, "CLONE_UNTRACED"},
-    {CLONE_VFORK, "CLONE_VFORK"},
-    {CLONE_VM, "CLONE_VM"},
-};
-
-const std::map<int, std::string> futex_flags{
-    {FUTEX_WAKE_BITSET, "FUTEX_WAKE_BITSET"},
-    {FUTEX_WAIT, "FUTEX_WAIT"},
-    {FUTEX_WAKE, "FUTEX_WAKE"},
-    {FUTEX_FD, "FUTEX_FD"},
-    {FUTEX_REQUEUE, "FUTEX_REQUEUE"},
-    {FUTEX_CMP_REQUEUE, "FUTEX_CMP_REQUEUE"},
-    {FUTEX_WAKE_OP, "FUTEX_WAKE_OP"},
-    {FUTEX_WAIT_BITSET, "FUTEX_WAIT_BITSET"},
-    {FUTEX_LOCK_PI, "FUTEX_LOCK_PI"},
-    {FUTEX_LOCK_PI2, "FUTEX_LOCK_PI2"},
-    {FUTEX_TRYLOCK_PI, "FUTEX_TRYLOCK_PI"},
-    {FUTEX_UNLOCK_PI, "FUTEX_UNLOCK_PI"},
-    {FUTEX_CMP_REQUEUE_PI, "FUTEX_CMP_REQUEUE_PI"},
-    {FUTEX_WAIT_REQUEUE_PI, "FUTEX_WAIT_REQUEUE_PI"},
-};
-
-const std::set<int> futex_ops_with_val2{FUTEX_CMP_REQUEUE, FUTEX_WAKE_OP,
-                                        FUTEX_CMP_REQUEUE_PI};
-
-const std::set<int> futex_ops_with_timeout{FUTEX_WAIT, FUTEX_WAIT_BITSET,
-                                           FUTEX_LOCK_PI, FUTEX_LOCK_PI2,
-                                           FUTEX_WAIT_REQUEUE_PI};
-
-const std::map<int, std::string> ioctls{
-    VAL(TCGETS), VAL(TCSETS), VAL(TCSETSW), VAL(TCSETSF), VAL(TCGETA),
-    VAL(TCSETA), VAL(TCSETAW), VAL(TCSETAF), VAL(TCSBRK), VAL(TCXONC),
-    VAL(TCFLSH), VAL(TIOCEXCL), VAL(TIOCNXCL), VAL(TIOCSCTTY), VAL(TIOCGPGRP),
-    VAL(TIOCSPGRP), VAL(TIOCOUTQ), VAL(TIOCSTI), VAL(TIOCGWINSZ),
-    VAL(TIOCSWINSZ), VAL(TIOCMGET), VAL(TIOCMBIS), VAL(TIOCMBIC), VAL(TIOCMSET),
-    VAL(TIOCGSOFTCAR), VAL(TIOCSSOFTCAR), VAL(FIONREAD), VAL(TIOCINQ),
-    VAL(TIOCLINUX), VAL(TIOCCONS), VAL(TIOCGSERIAL), VAL(TIOCSSERIAL),
-    VAL(TIOCPKT), VAL(FIONBIO), VAL(TIOCNOTTY), VAL(TIOCSETD), VAL(TIOCGETD),
-    VAL(TCSBRKP), VAL(TIOCSBRK), VAL(TIOCCBRK), VAL(TIOCGSID),
-    // VAL(TCGETS2), VAL(TCSETS2), VAL(TCSETSW2), VAL(TCSETSF2),
-    VAL(TIOCGRS485), VAL(TIOCSRS485), VAL(TIOCGPTN), VAL(TIOCSPTLCK),
-    VAL(TCGETX), VAL(TCSETX), VAL(TCSETXF), VAL(TCSETXW), VAL(FIONCLEX),
-    VAL(FIOCLEX), VAL(FIOASYNC), VAL(TIOCSERCONFIG), VAL(TIOCSERGWILD),
-    VAL(TIOCSERSWILD), VAL(TIOCGLCKTRMIOS), VAL(TIOCSLCKTRMIOS),
-    VAL(TIOCSERGSTRUCT), VAL(TIOCSERGETLSR), VAL(TIOCSERGETMULTI),
-    VAL(TIOCSERSETMULTI), VAL(TIOCMIWAIT), VAL(TIOCGICOUNT),
-    // VAL(TIOCGHAYESESP), VAL(TIOCSHAYESESP),
-    VAL(TIOCPKT_DATA), VAL(TIOCPKT_FLUSHREAD), VAL(TIOCPKT_FLUSHWRITE),
-    VAL(TIOCPKT_STOP), VAL(TIOCPKT_START), VAL(TIOCPKT_NOSTOP),
-    VAL(TIOCPKT_DOSTOP), VAL(TIOCSER_TEMT), VAL(TIOCGPTPEER)};
-
-const std::map<int, std::string> fcntls{
-    VAL(F_DUPFD),
-    VAL(F_DUPFD_CLOEXEC),
-    VAL(F_GETFD),
-    VAL(F_SETFD),
-    VAL(F_GETFL),
-    VAL(F_SETFL),
-    VAL(F_SETLK),
-    VAL(F_SETLKW),
-    VAL(F_GETLK),
-    VAL(F_OFD_SETLK),
-    VAL(F_OFD_SETLKW),
-    VAL(F_OFD_GETLK),
-    VAL(F_GETOWN),
-    VAL(F_SETOWN),
-    VAL(F_GETOWN_EX),
-    VAL(F_SETOWN_EX),
-    VAL(F_GETSIG),
-    VAL(F_SETSIG),
-    VAL(F_SETLEASE),
-    VAL(F_GETLEASE),
-    VAL(F_NOTIFY),
-    VAL(F_SETPIPE_SZ),
-    VAL(F_GETPIPE_SZ),
-    VAL(F_ADD_SEALS),
-    VAL(F_GET_SEALS),
-    VAL(F_GET_RW_HINT),
-    VAL(F_SET_RW_HINT),
-    VAL(F_GET_FILE_RW_HINT),
-    VAL(F_SET_FILE_RW_HINT),
-};
-
-const std::map<int, std::string> statx_mask_flags{
-    VAL(STATX_TYPE),
-    VAL(STATX_MODE),
-    VAL(STATX_NLINK),
-    VAL(STATX_UID),
-    VAL(STATX_GID),
-    VAL(STATX_ATIME),
-    VAL(STATX_MTIME),
-    VAL(STATX_CTIME),
-    VAL(STATX_INO),
-    VAL(STATX_SIZE),
-    VAL(STATX_BLOCKS),
-    VAL(STATX_BASIC_STATS),
-    // VAL(STATX_ALL), // same as STATX_BASIC_STATS | STATX_BTIME
-    VAL(STATX_BTIME),
-    VAL(STATX_MNT_ID),
-    VAL(STATX_DIOALIGN),
-};
-
-const std::map<int, std::string> at_flags{
-    VAL(AT_SYMLINK_NOFOLLOW),
-    VAL(AT_REMOVEDIR),
-    VAL(AT_SYMLINK_FOLLOW),
-    VAL(AT_NO_AUTOMOUNT),
-    VAL(AT_EMPTY_PATH),
-    VAL(AT_STATX_SYNC_TYPE),
-    VAL(AT_STATX_SYNC_AS_STAT),
-    VAL(AT_STATX_FORCE_SYNC),
-    VAL(AT_STATX_DONT_SYNC),
-    VAL(AT_RECURSIVE),
-    VAL(AT_EACCESS),
-};
 
 #ifndef PR_SET_VMA
 #define PR_SET_VMA 0x53564d41
@@ -314,115 +94,11 @@ void PrintEscapedString(std::span<const char> str, rt::Logger &ss) {
   ss << "\"";
 }
 
-const std::map<int, std::string> poll_flags{
-    VAL(POLLIN),     VAL(POLLPRI),    VAL(POLLOUT),    VAL(POLLRDHUP),
-    VAL(POLLERR),    VAL(POLLHUP),    VAL(POLLNVAL),   VAL(POLLRDNORM),
-    VAL(POLLRDBAND), VAL(POLLWRNORM), VAL(POLLWRBAND), VAL(POLLMSG)};
-
-const std::map<int, std::string> prctl_ops{
-    VAL(PR_CAP_AMBIENT),
-    VAL(PR_CAPBSET_READ),
-    VAL(PR_CAPBSET_DROP),
-    VAL(PR_SET_CHILD_SUBREAPER),
-    VAL(PR_GET_CHILD_SUBREAPER),
-    VAL(PR_SET_DUMPABLE),
-    VAL(PR_GET_DUMPABLE),
-    VAL(PR_SET_ENDIAN),
-    VAL(PR_GET_ENDIAN),
-    VAL(PR_SET_FP_MODE),
-    VAL(PR_GET_FP_MODE),
-    VAL(PR_SET_FPEMU),
-    VAL(PR_GET_FPEMU),
-    VAL(PR_SET_FPEXC),
-    VAL(PR_GET_FPEXC),
-    VAL(PR_SET_IO_FLUSHER),
-    VAL(PR_GET_IO_FLUSHER),
-    VAL(PR_SET_KEEPCAPS),
-    VAL(PR_GET_KEEPCAPS),
-    VAL(PR_MCE_KILL),
-    VAL(PR_MCE_KILL_GET),
-    VAL(PR_SET_MM),
-    VAL(PR_SET_VMA),
-    VAL(PR_MPX_ENABLE_MANAGEMENT),
-    VAL(PR_MPX_DISABLE_MANAGEMENT),
-    VAL(PR_SET_NAME),
-    VAL(PR_GET_NAME),
-    VAL(PR_SET_NO_NEW_PRIVS),
-    VAL(PR_GET_NO_NEW_PRIVS),
-    VAL(PR_PAC_RESET_KEYS),
-    VAL(PR_SET_PDEATHSIG),
-    VAL(PR_GET_PDEATHSIG),
-    VAL(PR_SET_PTRACER),
-    VAL(PR_SET_SECCOMP),
-    VAL(PR_GET_SECCOMP),
-    VAL(PR_SET_SECUREBITS),
-    VAL(PR_GET_SECUREBITS),
-    VAL(PR_GET_SPECULATION_CTRL),
-    VAL(PR_SET_SPECULATION_CTRL),
-    VAL(PR_SVE_SET_VL),
-    VAL(PR_SVE_GET_VL),
-    VAL(PR_SET_SYSCALL_USER_DISPATCH),
-    VAL(PR_SET_TAGGED_ADDR_CTRL),
-    VAL(PR_GET_TAGGED_ADDR_CTRL),
-    VAL(PR_TASK_PERF_EVENTS_DISABLE),
-    VAL(PR_TASK_PERF_EVENTS_ENABLE),
-    VAL(PR_SET_THP_DISABLE),
-    VAL(PR_GET_THP_DISABLE),
-    VAL(PR_GET_TID_ADDRESS),
-    VAL(PR_SET_TIMERSLACK),
-    VAL(PR_GET_TIMERSLACK),
-    VAL(PR_SET_TIMING),
-    VAL(PR_GET_TIMING),
-    VAL(PR_SET_TSC),
-    VAL(PR_GET_TSC),
-    VAL(PR_SET_UNALIGN),
-    VAL(PR_GET_UNALIGN),
-    VAL(PR_GET_AUXV),
-    VAL(PR_SET_MDWE),
-    VAL(PR_GET_MDWE),
-};
-
 std::string GetFcntlName(int cmd) {
   auto it = fcntls.find(cmd);
   if (it != fcntls.end()) return it->second;
   return std::to_string(cmd);
 }
-
-const std::map<int, std::string> sock_domains{
-    VAL(AF_UNIX),   VAL(AF_LOCAL),     VAL(AF_INET),    VAL(AF_AX25),
-    VAL(AF_IPX),    VAL(AF_APPLETALK), VAL(AF_X25),     VAL(AF_INET6),
-    VAL(AF_DECnet), VAL(AF_KEY),       VAL(AF_NETLINK), VAL(AF_PACKET),
-    VAL(AF_RDS),    VAL(AF_PPPOX),     VAL(AF_LLC),     VAL(AF_IB),
-    VAL(AF_MPLS),   VAL(AF_CAN),       VAL(AF_TIPC),    VAL(AF_BLUETOOTH),
-    VAL(AF_ALG),    VAL(AF_VSOCK),     VAL(AF_KCM),     VAL(AF_XDP),
-};
-
-const std::map<int, std::string> sock_types{
-    VAL(SOCK_STREAM), VAL(SOCK_DGRAM), VAL(SOCK_SEQPACKET),
-    VAL(SOCK_RAW),    VAL(SOCK_RDM),   VAL(SOCK_PACKET),
-};
-
-const std::map<int, std::string> msg_flags{
-    VAL(MSG_CMSG_CLOEXEC), VAL(MSG_DONTWAIT), VAL(MSG_ERRQUEUE),
-    VAL(MSG_OOB),          VAL(MSG_PEEK),     VAL(MSG_TRUNC),
-    VAL(MSG_WAITALL),      VAL(MSG_CONFIRM),  VAL(MSG_DONTROUTE),
-    VAL(MSG_EOR),          VAL(MSG_MORE),     VAL(MSG_NOSIGNAL),
-    VAL(MSG_OOB),
-};
-
-const std::map<int, std::string> epoll_ctl_ops{
-    VAL(EPOLL_CTL_ADD), VAL(EPOLL_CTL_MOD), VAL(EPOLL_CTL_DEL)};
-
-const char *sigmap[] = {
-    "SIGHUP",  "SIGINT",    "SIGQUIT", "SIGILL",    "SIGTRAP", "SIGABRT",
-    "SIGBUS",  "SIGFPE",    "SIGKILL", "SIGUSR1",   "SIGSEGV", "SIGUSR2",
-    "SIGPIPE", "SIGALRM",   "SIGTERM", "SIGSTKFLT", "SIGCHLD", "SIGCONT",
-    "SIGSTOP", "SIGTSTP",   "SIGTTIN", "SIGTTOU",   "SIGURG",  "SIGXCPU",
-    "SIGXFSZ", "SIGVTALRM", "SIGPROF", "SIGWINCH",  "SIGIO",   "SIGPWR",
-    "SIGSYS",  "SIGUNUSED"};
-
-const std::map<int, std::string> sigprocmask_how{
-    VAL(SIG_BLOCK), VAL(SIG_UNBLOCK), VAL(SIG_SETMASK)};
 
 void PrintSigset(const sigset_t *sigmask, rt::Logger &ss) {
   if (!sigmask) {
@@ -439,7 +115,7 @@ void PrintSigset(const sigset_t *sigmask, rt::Logger &ss) {
     if (done_one) ss << ",";
     done_one = true;
 
-    if (i < ARRAY_SIZE(sigmap))
+    if (i < kNumSignals)
       ss << sigmap[i];
     else
       ss << "SIGRT" << i;
@@ -565,7 +241,7 @@ void PrintArg(int advice, MAdviseHint, rt::Logger &ss,
 
 void PrintArg(int signo, SignalNumber, rt::Logger &ss,
               [[maybe_unused]] SyscallCtx &ctx) {
-  if (static_cast<size_t>(signo) <= ARRAY_SIZE(sigmap))
+  if (static_cast<size_t>(signo) <= kNumSignals)
     ss << sigmap[signo - 1];
   else
     ss << "SIGRT" << signo;
@@ -628,11 +304,6 @@ bool PrintArg(const struct epoll_event *el, rt::Logger &ss, SyscallCtx &ctx) {
   ss << ", data=" << el->data.u64 << "}";
   return true;
 }
-
-const std::map<int, std::string> wait_flags = {
-    VAL(WEXITED), VAL(WSTOPPED),  VAL(WCONTINUED), VAL(WNOHANG),
-    VAL(WNOWAIT), VAL(WUNTRACED), VAL(WCONTINUED),
-};
 
 void PrintArg(int prot, ProtFlag, rt::Logger &ss,
               [[maybe_unused]] SyscallCtx &ctx) {
@@ -708,161 +379,34 @@ void PrintArg(int *fds, FDPair *, rt::Logger &ss,
   ss << "[" << fds[0] << ", " << fds[1] << "]";
 }
 
-const std::map<int, std::string> sockopt_levels = {
-    VAL(SOL_SOCKET),   VAL(IPPROTO_IP),  VAL(IPPROTO_TCP), VAL(IPPROTO_UDP),
-    VAL(IPPROTO_IPV6), VAL(IPPROTO_RAW), VAL(SOL_NETLINK),
-};
-
-const std::map<int, std::string> sock_options = {
-    VAL(SO_DEBUG),
-    VAL(SO_REUSEADDR),
-    VAL(SO_TYPE),
-    VAL(SO_ERROR),
-    VAL(SO_DONTROUTE),
-    VAL(SO_BROADCAST),
-    VAL(SO_SNDBUF),
-    VAL(SO_RCVBUF),
-    VAL(SO_KEEPALIVE),
-    VAL(SO_OOBINLINE),
-    VAL(SO_NO_CHECK),
-    VAL(SO_PRIORITY),
-    VAL(SO_LINGER),
-    VAL(SO_BSDCOMPAT),
-    VAL(SO_REUSEPORT),
-    VAL(SO_PASSCRED),
-    VAL(SO_PEERCRED),
-    VAL(SO_RCVLOWAT),
-    VAL(SO_SNDLOWAT),
-    VAL(SO_RCVTIMEO),
-    VAL(SO_SNDTIMEO),
-    VAL(SO_SECURITY_AUTHENTICATION),
-    VAL(SO_SECURITY_ENCRYPTION_TRANSPORT),
-    VAL(SO_SECURITY_ENCRYPTION_NETWORK),
-    VAL(SO_BINDTODEVICE),
-    VAL(SO_DETACH_FILTER),
-    VAL(SO_PEERNAME),
-    VAL(SO_TIMESTAMP_OLD),
-    VAL(SO_ACCEPTCONN),
-    VAL(SO_PEERSEC),
-    VAL(SO_SNDBUFFORCE),
-    VAL(SO_RCVBUFFORCE),
-    VAL(SO_PASSSEC),
-    VAL(SO_TIMESTAMPNS_OLD),
-    VAL(SO_MARK),
-    VAL(SO_TIMESTAMPING_OLD),
-    VAL(SO_PROTOCOL),
-    VAL(SO_DOMAIN),
-    VAL(SO_RXQ_OVFL),
-    VAL(SO_WIFI_STATUS),
-    VAL(SO_PEEK_OFF),
-    VAL(SO_NOFCS),
-    VAL(SO_LOCK_FILTER),
-    VAL(SO_SELECT_ERR_QUEUE),
-    VAL(SO_BUSY_POLL),
-    VAL(SO_MAX_PACING_RATE),
-    VAL(SO_BPF_EXTENSIONS),
-    VAL(SO_INCOMING_CPU),
-    VAL(SO_ATTACH_BPF),
-    VAL(SO_ATTACH_REUSEPORT_CBPF),
-    VAL(SO_ATTACH_REUSEPORT_EBPF),
-    VAL(SO_CNX_ADVICE),
-    VAL(SO_MEMINFO),
-    VAL(SO_INCOMING_NAPI_ID),
-    VAL(SO_COOKIE),
-    VAL(SO_PEERGROUPS),
-    VAL(SO_ZEROCOPY),
-    VAL(SO_TXTIME),
-    VAL(SO_BINDTOIFINDEX),
-    VAL(SO_TIMESTAMP_NEW),
-    VAL(SO_TIMESTAMPNS_NEW),
-    VAL(SO_TIMESTAMPING_NEW),
-    VAL(SO_RCVTIMEO_NEW),
-    VAL(SO_SNDTIMEO_NEW),
-    VAL(SO_DETACH_REUSEPORT_BPF),
-    VAL(SO_PREFER_BUSY_POLL),
-    VAL(SO_BUSY_POLL_BUDGET),
-    VAL(SO_NETNS_COOKIE),
-    VAL(SO_BUF_LOCK),
-    VAL(SO_RESERVE_MEM),
-    VAL(SO_TXREHASH),
-    VAL(SO_RCVMARK),
-    VAL(SO_PASSPIDFD),
-    VAL(SO_PEERPIDFD),
-    // VAL(SO_RCVPRIORITY),
-    // VAL(SO_PASSRIGHTS),
-    // VAL(SO_INQ),
-};
-
-const std::set<int> intlike_sockopts = {
-    SO_DEBUG,
-    SO_REUSEADDR,
-    SO_DONTROUTE,
-    SO_BROADCAST,
-    SO_SNDBUF,
-    SO_RCVBUF,
-    SO_KEEPALIVE,
-    SO_OOBINLINE,
-    SO_NO_CHECK,
-    SO_PRIORITY,
-    SO_BSDCOMPAT,
-    SO_REUSEPORT,
-    SO_PASSCRED,
-    SO_RCVLOWAT,
-    SO_SNDLOWAT,
-    SO_DETACH_FILTER,
-    SO_TIMESTAMP_OLD,
-    SO_ACCEPTCONN,
-    SO_SNDBUFFORCE,
-    SO_RCVBUFFORCE,
-    SO_PASSSEC,
-    SO_TIMESTAMPNS_OLD,
-    SO_MARK,
-    SO_TIMESTAMPING_OLD,
-    SO_RXQ_OVFL,
-    SO_WIFI_STATUS,
-    SO_PEEK_OFF,
-    SO_NOFCS,
-    SO_LOCK_FILTER,
-    SO_SELECT_ERR_QUEUE,
-    SO_BUSY_POLL,
-    SO_INCOMING_CPU,
-    SO_CNX_ADVICE,
-    SO_INCOMING_NAPI_ID,
-    SO_ZEROCOPY,
-    SO_TIMESTAMP_NEW,
-    SO_TIMESTAMPNS_NEW,
-    SO_TIMESTAMPING_NEW,
-    SO_DETACH_REUSEPORT_BPF,
-    SO_PREFER_BUSY_POLL,
-    SO_BUSY_POLL_BUDGET,
-    SO_RESERVE_MEM,
-    SO_RCVMARK,
-    SO_PASSPIDFD,
-    // SO_RCVPRIORITY,
-    // SO_PASSRIGHTS,
-    // SO_INQ
-};
-
 void PrintArg(int level, SockoptLevel, rt::Logger &ss, SyscallCtx &ctx) {
   PrintValMap(sockopt_levels, level, ss);
   int sockopt = std::get<2>(ctx.args);
+
+  auto sockopt_handler = [&](const std::map<int, std::string> &val_map,
+                             const std::set<int> &intlike_sockopts) {
+    auto it = val_map.find(sockopt);
+    LOG(ERR) << "Unknown sockopt: " << sockopt;
+    if (it == val_map.end()) return;
+    ctx.arg_strs[2].emplace(it->second);
+    if (intlike_sockopts.count(sockopt)) {
+      ctx.arg_strs[3].emplace()
+          << "[" << *reinterpret_cast<int *>(std::get<3>(ctx.args)) << "]";
+    }
+  };
   switch (level) {
-    case SOL_SOCKET: {
-      auto it = sock_options.find(sockopt);
-      if (it == sock_options.end()) return;
-      ctx.arg_strs[2].emplace(it->second);
-      if (intlike_sockopts.count(sockopt)) {
-        ctx.arg_strs[3].emplace()
-            << "[" << *reinterpret_cast<int *>(std::get<3>(ctx.args)) << "]";
-        ctx.arg_strs[4].emplace();
-      } else if (sockopt == SO_RCVTIMEO || sockopt == SO_SNDTIMEO) {
+    case IPPROTO_IP:
+      sockopt_handler(ip_options, ip_int_options);
+      break;
+    // TODO: add TCP and UDP options
+    case SOL_SOCKET:
+      sockopt_handler(sock_options, intlike_sockopts);
+      if (sockopt == SO_RCVTIMEO || sockopt == SO_SNDTIMEO) {
         struct timeval tv =
             *reinterpret_cast<struct timeval *>(std::get<3>(ctx.args));
         PrintArg(tv, ctx.arg_strs[3].emplace());
-        ctx.arg_strs[4].emplace();
       }
       break;
-    }
     default:
       break;
   }

--- a/junction/syscall/strace.cc
+++ b/junction/syscall/strace.cc
@@ -194,6 +194,19 @@ const std::map<int, std::string> fcntls{
     VAL(F_SET_FILE_RW_HINT),
 };
 
+#ifndef PR_SET_VMA
+#define PR_SET_VMA 0x53564d41
+#endif
+
+#ifndef PR_GET_AUXV
+#define PR_GET_AUXV 0x41555856
+#endif
+
+#ifndef PR_SET_MDWE
+#define PR_SET_MDWE 65
+#define PR_GET_MDWE 66
+#endif
+
 const std::map<int, std::string> prctl_ops{
     VAL(PR_CAP_AMBIENT),
     VAL(PR_CAPBSET_READ),

--- a/junction/syscall/strace.cc
+++ b/junction/syscall/strace.cc
@@ -486,6 +486,15 @@ void PrintArg(int op, SocketType, rt::Logger &ss,
   if (op & SOCK_CLOEXEC) ss << "|SOCK_CLOEXEC";
 }
 
+void PrintArg(const struct msghdr &msg, rt::Logger &ss) {
+  ss << "{msg_name=";
+  PrintArg(reinterpret_cast<const struct sockaddr *>(msg.msg_name), ss);
+  ss << ", msg_namelen=" << msg.msg_namelen << ", msg_iov=" << msg.msg_iov
+     << ", msg_iovlen=" << msg.msg_iovlen << ", msg_control=" << msg.msg_control
+     << ", msg_controllen=" << msg.msg_controllen
+     << ", msg_flags=" << msg.msg_flags << "}";
+}
+
 void PrintArg(int advice, MAdviseHint, rt::Logger &ss,
               [[maybe_unused]] SyscallCtx &ctx) {
   PrintValMap(madvise_hints, advice, ss);
@@ -519,8 +528,9 @@ void PrintArg(int fd, AtFD, rt::Logger &ss, [[maybe_unused]] SyscallCtx &ctx) {
     ss << fd;
 }
 
+template <typename Logger>
 bool PrintFlagArr(const std::map<int, std::string> &map, int flags,
-                  rt::Logger &ss) {
+                  Logger &ss) {
   bool done_one = false;
   for (int i = 0; i < 32; i++) {
     int flag = 1 << i;
@@ -599,23 +609,37 @@ void PrintArg(long op, PrctlOp, rt::Logger &ss,
   PrintValMap(prctl_ops, op, ss);
 }
 
+template <typename Logger>
+void PrintOpenFlag(int flags, Logger &ss, bool include_mode = true) {
+  bool done_one = PrintFlagArr(open_flags, flags, ss);
+  if (include_mode && (flags & (O_WRONLY | O_RDWR)) == 0) {
+    if (done_one) ss << "|";
+    ss << "O_RDONLY";
+  }
+}
+
+void PrintArg(int flags, OpenFlag, rt::Logger &ss,
+              [[maybe_unused]] SyscallCtx &ctx) {
+  PrintOpenFlag(flags, ss);
+}
+
 void PrintArg(unsigned int op, FcntlOp, rt::Logger &ss,
               [[maybe_unused]] SyscallCtx &ctx) {
   PrintValMap(fcntls, op, ss);
+  if (op == F_SETFL) {
+    PrintOpenFlag(static_cast<int>(std::get<2>(ctx.args)),
+                  ctx.arg_strs[2].emplace(), false);
+  } else if (op == F_GETFL && ctx.retval) {
+    PrintOpenFlag(static_cast<int>(ctx.retval.value()), ctx.ret_str.emplace());
+  }
 }
 
 void PrintArg(unsigned int op, IoctlOp, rt::Logger &ss,
               [[maybe_unused]] SyscallCtx &ctx) {
   if (!PrintValMap(ioctls, op, ss, false)) PrintIoctlReq(op, ss);
-}
-
-void PrintArg(int flags, OpenFlag, rt::Logger &ss,
-              [[maybe_unused]] SyscallCtx &ctx) {
-  bool done_one = PrintFlagArr(open_flags, flags, ss);
-  if ((flags & (O_WRONLY | O_RDWR)) == 0) {
-    if (done_one) ss << "|";
-    ss << "O_RDONLY";
-  }
+  if (op == FIONBIO)
+    ctx.arg_strs[2].emplace()
+        << "[" << *reinterpret_cast<int *>(std::get<2>(ctx.args)) << "]";
 }
 
 void PrintArg(int *fds, FDPair *, rt::Logger &ss,

--- a/junction/syscall/strace.cc
+++ b/junction/syscall/strace.cc
@@ -8,6 +8,7 @@ extern "C" {
 #include <signal.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 }
 
@@ -192,6 +193,39 @@ const std::map<int, std::string> fcntls{
     VAL(F_SET_RW_HINT),
     VAL(F_GET_FILE_RW_HINT),
     VAL(F_SET_FILE_RW_HINT),
+};
+
+const std::map<int, std::string> statx_mask_flags{
+    VAL(STATX_TYPE),
+    VAL(STATX_MODE),
+    VAL(STATX_NLINK),
+    VAL(STATX_UID),
+    VAL(STATX_GID),
+    VAL(STATX_ATIME),
+    VAL(STATX_MTIME),
+    VAL(STATX_CTIME),
+    VAL(STATX_INO),
+    VAL(STATX_SIZE),
+    VAL(STATX_BLOCKS),
+    VAL(STATX_BASIC_STATS),
+    // VAL(STATX_ALL), // same as STATX_BASIC_STATS | STATX_BTIME
+    VAL(STATX_BTIME),
+    VAL(STATX_MNT_ID),
+    VAL(STATX_DIOALIGN),
+};
+
+const std::map<int, std::string> at_flags{
+    VAL(AT_SYMLINK_NOFOLLOW),
+    VAL(AT_REMOVEDIR),
+    VAL(AT_SYMLINK_FOLLOW),
+    VAL(AT_NO_AUTOMOUNT),
+    VAL(AT_EMPTY_PATH),
+    VAL(AT_STATX_SYNC_TYPE),
+    VAL(AT_STATX_SYNC_AS_STAT),
+    VAL(AT_STATX_FORCE_SYNC),
+    VAL(AT_STATX_DONT_SYNC),
+    VAL(AT_RECURSIVE),
+    VAL(AT_EACCESS),
 };
 
 #ifndef PR_SET_VMA
@@ -451,7 +485,10 @@ void PrintArg(int op, EpollOp, rt::Logger &ss) {
 }
 
 void PrintArg(const char *arg, PathName *, rt::Logger &ss) {
-  ss << "\"" << arg << "\"";
+  if (!arg)
+    ss << "<null>";
+  else
+    ss << "\"" << arg << "\"";
 }
 
 void PrintArg(int fd, AtFD, rt::Logger &ss) {
@@ -464,13 +501,19 @@ void PrintArg(int fd, AtFD, rt::Logger &ss) {
 bool PrintFlagArr(const std::map<int, std::string> &map, int flags,
                   rt::Logger &ss) {
   bool done_one = false;
-  for (const auto &[flag, name] : map) {
+  for (int i = 0; i < 32; i++) {
+    int flag = 1 << i;
     if (!(flags & flag)) continue;
     if (!done_one)
       done_one = true;
     else
       ss << "|";
-    ss << name;
+    auto it = map.find(flag);
+    if (it != map.end()) {
+      ss << it->second;
+    } else {
+      ss << "1 << " << i;
+    }
   }
   return done_one;
 }
@@ -494,17 +537,10 @@ bool PrintArg(const struct epoll_event el, rt::Logger &ss, bool first) {
   return true;
 }
 
-void PrintArg(int option, WaitOptions, rt::Logger &ss) {
-  const static std::map<int, std::string> flags = {
-      VAL(WEXITED), VAL(WSTOPPED),  VAL(WCONTINUED), VAL(WNOHANG),
-      VAL(WNOWAIT), VAL(WUNTRACED), VAL(WCONTINUED),
-  };
-  PrintFlagArr(flags, option, ss);
-}
-
-void PrintArg(int op, MessageFlag, rt::Logger &ss) {
-  PrintFlagArr(msg_flags, op, ss);
-}
+const std::map<int, std::string> wait_flags = {
+    VAL(WEXITED), VAL(WSTOPPED),  VAL(WCONTINUED), VAL(WNOHANG),
+    VAL(WNOWAIT), VAL(WUNTRACED), VAL(WCONTINUED),
+};
 
 void PrintArg(int prot, ProtFlag, rt::Logger &ss) {
   if (prot == PROT_NONE) {
@@ -536,14 +572,6 @@ void PrintArg(unsigned int op, FcntlOp, rt::Logger &ss) {
 
 void PrintArg(unsigned int op, IoctlOp, rt::Logger &ss) {
   if (!PrintValMap(ioctls, op, ss, false)) PrintIoctlReq(op, ss);
-}
-
-void PrintArg(int flags, MMapFlag, rt::Logger &ss) {
-  PrintFlagArr(mmap_flags, flags, ss);
-}
-
-void PrintArg(unsigned long flags, CloneFlag, rt::Logger &ss) {
-  PrintFlagArr(clone_flags, flags, ss);
 }
 
 void PrintArg(int flags, OpenFlag, rt::Logger &ss) {

--- a/junction/syscall/strace.h
+++ b/junction/syscall/strace.h
@@ -24,6 +24,7 @@ struct SyscallCtx {
   std::tuple<long, long, long, long, long, long> args;
   long sysn;
   std::optional<std::stringstream> arg_strs[6];
+  std::optional<std::stringstream> ret_str;
   std::optional<long> retval;
 };
 
@@ -83,15 +84,15 @@ inline void PrintArg(const char *arg, T, rt::Logger &ss,
   enum class type_name : int {};                  \
   void PrintArg(type_type, type_name, rt::Logger &ss, SyscallCtx &ctx);
 
-extern bool PrintFlagArr(const std::map<int, std::string> &map, int flags,
-                         rt::Logger &ss);
+template <typename Logger>
+bool PrintFlagArr(const std::map<int, std::string> &map, int flags, Logger &ss);
 
 #define DECLARE_STRACE_FLAG_ARR(type_name, type_type, map_name)    \
   enum class type_name : int {};                                   \
   extern const std::map<int, std::string> map_name;                \
   inline void PrintArg(type_type flags, type_name, rt::Logger &ss, \
                        [[maybe_unused]] SyscallCtx &ctx) {         \
-    PrintFlagArr(map_name, flags, ss);                             \
+    if (!PrintFlagArr(map_name, flags, ss)) ss << 0;               \
   }
 
 DECLARE_STRACE_TYPE(SockoptLevel, int);
@@ -130,6 +131,29 @@ inline void PrintArg(const std::vector<std::string_view> &arg,
 }
 
 void PrintArg(const struct sockaddr *addr, rt::Logger &ss);
+
+// void PrintArg(const struct msghdr *msg, rt::Logger &ss);
+void PrintArg(const struct msghdr &msg, rt::Logger &ss);
+
+inline bool PrintArg(const struct mmsghdr &msg, rt::Logger &ss, bool first) {
+  if (!first) ss << ", ";
+  ss << "{msg_len=" << msg.msg_len << ", msg_hdr=";
+  PrintArg(msg.msg_hdr, ss);
+  ss << "}";
+  return true;
+}
+
+template <typename U>
+inline void PrintArg(const struct msghdr *msg, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
+  PrintArg(*msg, ss);
+}
+
+template <typename U>
+inline void PrintArg(struct msghdr *msg, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
+  PrintArg(*msg, ss);
+}
 
 template <typename Logger>
 inline void PrintArg(const struct timespec *t, Logger &ss) {
@@ -299,6 +323,7 @@ void LogSyscall(strace::SyscallCtx &ctx, Ret retval, std::string_view name,
     strace::UnpackArgs<n_args - 1>(logger, fn, args_t, ctx);
   }
   logger << ") = " << retval;
+  if (ctx.ret_str) logger << " (" << ctx.ret_str.value().str() << ")";
   if ((long)retval < 0) logger << " [" << Error(-((long)retval)) << "]";
 }
 

--- a/junction/syscall/strace.h
+++ b/junction/syscall/strace.h
@@ -343,9 +343,7 @@ inline void PrintArg(T *, ArrayInfo *arrinfo, rt::Logger &ss,
 template <typename T>
 inline void PrintArg(T *, ByteSpan *binfo, rt::Logger &ss,
                      [[maybe_unused]] SyscallCtx &ctx) {
-  if (binfo->size <= 0) {
-    return;
-  }
+  if (binfo->size <= 0) { return; }
   // Make a span from the array info
   std::span<const char> span(reinterpret_cast<const char *>(binfo->ptr),
                              binfo->size);

--- a/junction/syscall/strace.h
+++ b/junction/syscall/strace.h
@@ -190,6 +190,31 @@ constexpr void UnpackArgs(rt::Logger &ss, Ret (*fn)(UsysArgs...), ArgT &args,
 
 std::string GetFcntlName(int cmd);
 
+struct ArrayInfo {
+  void *ptr;
+  size_t size;
+};
+
+bool PrintArg(struct pollfd el, rt::Logger &ss, bool first);
+bool PrintArg(const struct epoll_event el, rt::Logger &ss, bool first);
+
+template <typename U>
+inline void PrintArgSpan(std::span<const U> span, rt::Logger &ss) {
+  ss << "[";
+  int cnt = 0;
+  for (const auto &el : span) {
+    if (PrintArg(el, ss, cnt == 0)) cnt++;
+  }
+  ss << "]";
+}
+
+template <typename T>
+inline void PrintArg(T *, ArrayInfo *arrinfo, rt::Logger &ss) {
+  // Make a span from the array info
+  std::span<const T> span(reinterpret_cast<T *>(arrinfo->ptr), arrinfo->size);
+  PrintArgSpan(span, ss);
+}
+
 }  // namespace strace
 
 template <typename Ret, typename... RegisterArgs, typename UsysRet,

--- a/junction/syscall/strace.h
+++ b/junction/syscall/strace.h
@@ -5,6 +5,10 @@
 #include "junction/bindings/log.h"
 #include "junction/kernel/proc.h"
 
+#ifndef P_PIDFD
+#define P_PIDFD 3
+#endif
+
 namespace junction {
 
 // Log a message that is prefixed with the PID and TID

--- a/junction/syscall/strace.h
+++ b/junction/syscall/strace.h
@@ -20,8 +20,16 @@ namespace strace {
 struct PathName {};
 struct FDPair {};
 
+struct SyscallCtx {
+  std::tuple<long, long, long, long, long, long> args;
+  long sysn;
+  std::optional<std::string> arg_strs[6];
+  std::optional<long> retval;
+};
+
 template <typename U>
-inline void PrintArg(const char **array, U, rt::Logger &ss) {
+inline void PrintArg(const char **array, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   ss << "[";
   int cnt = 0;
   while (*array) {
@@ -49,37 +57,41 @@ inline void PrintList(const U &array, rt::Logger &ss) {
 
 // Default: print any syscall argument using the defined type in usys.h.
 template <typename T, typename U>
-inline void PrintArg(const T arg, const U, rt::Logger &ss) {
+inline void PrintArg(const T arg, const U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   ss << arg;
 }
 
 // Override: don't print arguments with type char *.
 template <typename U>
-inline void PrintArg(char *arg, U, rt::Logger &ss) {
+inline void PrintArg(char *arg, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   ss << (void *)arg;
 }
 
 // Override: print char *s that are annotated as PathNames.
-void PrintArg(const char *arg, PathName *, rt::Logger &ss);
+void PrintArg(const char *arg, PathName *, rt::Logger &ss, SyscallCtx &ctx);
 
 // Don't print const char * args without a PathName annotation.
 template <typename T>
-inline void PrintArg(const char *arg, T, rt::Logger &ss) {
+inline void PrintArg(const char *arg, T, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   ss << (const void *)arg;
 }
 
 #define DECLARE_STRACE_TYPE(type_name, type_type) \
   enum class type_name : int {};                  \
-  void PrintArg(type_type, type_name, rt::Logger &ss);
+  void PrintArg(type_type, type_name, rt::Logger &ss, SyscallCtx &ctx);
 
 extern bool PrintFlagArr(const std::map<int, std::string> &map, int flags,
                          rt::Logger &ss);
 
-#define DECLARE_STRACE_FLAG_ARR(type_name, type_type, map_name)      \
-  enum class type_name : int {};                                     \
-  extern const std::map<int, std::string> map_name;                  \
-  inline void PrintArg(type_type flags, type_name, rt::Logger &ss) { \
-    PrintFlagArr(map_name, flags, ss);                               \
+#define DECLARE_STRACE_FLAG_ARR(type_name, type_type, map_name)    \
+  enum class type_name : int {};                                   \
+  extern const std::map<int, std::string> map_name;                \
+  inline void PrintArg(type_type flags, type_name, rt::Logger &ss, \
+                       [[maybe_unused]] SyscallCtx &ctx) {         \
+    PrintFlagArr(map_name, flags, ss);                             \
   }
 
 DECLARE_STRACE_TYPE(AtFD, int);
@@ -102,17 +114,24 @@ DECLARE_STRACE_FLAG_ARR(WaitOptions, int, wait_flags);
 DECLARE_STRACE_FLAG_ARR(StatxMask, unsigned int, statx_mask_flags);
 DECLARE_STRACE_FLAG_ARR(AtFlag, int, at_flags);
 
-void PrintArg(int *fds, FDPair *, rt::Logger &ss);
+inline void PrintArg(CloneFlag flags, CloneFlag, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
+  PrintFlagArr(clone_flags, static_cast<int>(flags), ss);
+}
+
+void PrintArg(int *fds, FDPair *, rt::Logger &ss, SyscallCtx &ctx);
 
 inline void PrintArg(const std::vector<std::string_view> &arg,
-                     const std::vector<std::string_view> &, rt::Logger &ss) {
+                     const std::vector<std::string_view> &, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   PrintList(arg, ss);
 }
 
 void PrintArg(const struct sockaddr *addr, rt::Logger &ss);
 
 template <typename U>
-inline void PrintArg(struct timespec *t, U, rt::Logger &ss) {
+inline void PrintArg(struct timespec *t, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   if (!t) {
     ss << "NULL";
     return;
@@ -125,7 +144,8 @@ inline void PrintArg(struct timeval tv, rt::Logger &ss) {
 }
 
 template <typename U>
-inline void PrintArg(const struct itimerval *it, U, rt::Logger &ss) {
+inline void PrintArg(const struct itimerval *it, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   if (!it) {
     ss << "NULL";
     return;
@@ -138,28 +158,33 @@ inline void PrintArg(const struct itimerval *it, U, rt::Logger &ss) {
 }
 
 template <typename U>
-inline void PrintArg(struct itimerval *it, U x, rt::Logger &ss) {
+inline void PrintArg(struct itimerval *it, U x, rt::Logger &ss,
+                     SyscallCtx &ctx) {
   const struct itimerval *cit = it;
-  PrintArg(cit, x, ss);
+  PrintArg(cit, x, ss, ctx);
 }
 
 template <typename U>
-inline void PrintArg(const struct sockaddr *addr, U, rt::Logger &ss) {
+inline void PrintArg(const struct sockaddr *addr, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   PrintArg(addr, ss);
 }
 
 template <typename U>
-inline void PrintArg(struct sockaddr *addr, U, rt::Logger &ss) {
+inline void PrintArg(struct sockaddr *addr, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   PrintArg(addr, ss);
 }
 
 template <typename U>
-inline void PrintArg(cap_user_header_t hdrp, U, rt::Logger &ss) {
+inline void PrintArg(cap_user_header_t hdrp, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   ss << "{" << hdrp->version << ", " << hdrp->pid << "}";
 }
 
 template <typename U>
-inline void PrintArg(struct stat *stat, U, rt::Logger &ss) {
+inline void PrintArg(struct stat *stat, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   ss << "{st_mode=";
   if ((stat->st_mode & kTypeMask) == kTypeRegularFile) ss << "S_IFREG";
   if ((stat->st_mode & kTypeMask) == kTypeDirectory) ss << "S_IFDIR";
@@ -173,7 +198,8 @@ inline void PrintArg(struct stat *stat, U, rt::Logger &ss) {
 }
 
 template <typename U>
-inline void PrintArg(idtype_t idt, U, rt::Logger &ss) {
+inline void PrintArg(idtype_t idt, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   if (idt == P_PID)
     ss << "P_PID";
   else if (idt == P_PIDFD)
@@ -186,31 +212,37 @@ inline void PrintArg(idtype_t idt, U, rt::Logger &ss) {
     ss << idt;
 }
 
-void PrintArg(const cap_user_data_t, rt::Logger &ss);
-
-void PrintArg(const sigset_t *sigmask, rt::Logger &ss);
+void PrintUserCap(const cap_user_data_t, rt::Logger &ss);
+void PrintSigset(const sigset_t *sigmask, rt::Logger &ss);
 
 template <typename U>
-inline void PrintArg(const sigset_t *mask, U, rt::Logger &ss) {
-  PrintArg(mask, ss);
+inline void PrintArg(const sigset_t *mask, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
+  PrintSigset(mask, ss);
 }
 
 template <typename U>
-inline void PrintArg(sigset_t *mask, U, rt::Logger &ss) {
-  PrintArg(mask, ss);
+inline void PrintArg(sigset_t *mask, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
+  PrintSigset(mask, ss);
 }
 
 template <typename U>
-inline void PrintArg(const cap_user_data_t datap, U, rt::Logger &ss) {
-  PrintArg(datap, ss);
+inline void PrintArg(const cap_user_data_t datap, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
+  PrintUserCap(datap, ss);
 }
 
 template <int N, typename Ret, typename... UsysArgs, typename ArgT>
 constexpr void UnpackArgs(rt::Logger &ss, Ret (*fn)(UsysArgs...), ArgT &args,
-                          bool last = true) {
-  if constexpr (N > 0) UnpackArgs<N - 1>(ss, fn, args, false);
-  using ArgType = std::tuple_element_t<N, std::tuple<UsysArgs...>>;
-  PrintArg(((const ArgType)std::get<N>(args)), std::get<N>(args), ss);
+                          SyscallCtx &ctx, bool last = true) {
+  if constexpr (N > 0) UnpackArgs<N - 1>(ss, fn, args, ctx, false);
+  if (ctx.arg_strs[N]) {
+    ss << *ctx.arg_strs[N];
+  } else {
+    using ArgType = std::tuple_element_t<N, std::tuple<UsysArgs...>>;
+    PrintArg(((const ArgType)std::get<N>(args)), std::get<N>(args), ss, ctx);
+  }
   if (!last) ss << ", ";
 }
 
@@ -235,7 +267,8 @@ inline void PrintArgSpan(std::span<const U> span, rt::Logger &ss) {
 }
 
 template <typename T>
-inline void PrintArg(T *, ArrayInfo *arrinfo, rt::Logger &ss) {
+inline void PrintArg(T *, ArrayInfo *arrinfo, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
   // Make a span from the array info
   std::span<const T> span(reinterpret_cast<T *>(arrinfo->ptr), arrinfo->size);
   PrintArgSpan(span, ss);
@@ -245,30 +278,30 @@ inline void PrintArg(T *, ArrayInfo *arrinfo, rt::Logger &ss) {
 
 template <typename Ret, typename... RegisterArgs, typename UsysRet,
           typename... UsysArgs>
-void LogSyscall(Ret retval, std::string_view name, UsysRet (*fn)(UsysArgs...),
-                RegisterArgs... args) {
+void LogSyscall(strace::SyscallCtx &ctx, Ret retval, std::string_view name,
+                UsysRet (*fn)(UsysArgs...), RegisterArgs... args) {
   rt::Logger logger(LOG_INFO);
   logger << "[" << myproc().get_pid() << ":" << mythread().get_tid() << "] ";
   logger << name << "(";
   constexpr size_t n_args = sizeof...(UsysArgs);
   if constexpr (n_args) {
     auto args_t = std::make_tuple(args...);
-    strace::UnpackArgs<n_args - 1>(logger, fn, args_t);
+    strace::UnpackArgs<n_args - 1>(logger, fn, args_t, ctx);
   }
   logger << ") = " << retval;
   if ((long)retval < 0) logger << " [" << Error(-((long)retval)) << "]";
 }
 
 template <typename... RegisterArgs, typename Ret, typename... UsysArgs>
-void LogSyscall(std::string_view name, Ret (*fn)(UsysArgs...),
-                RegisterArgs... args) {
+void LogSyscall(strace::SyscallCtx &ctx, std::string_view name,
+                Ret (*fn)(UsysArgs...), RegisterArgs... args) {
   rt::Logger logger(LOG_INFO);
   logger << "[" << myproc().get_pid() << ":" << mythread().get_tid() << "] ";
   logger << name << "(";
   constexpr size_t n_args = sizeof...(UsysArgs);
   if constexpr (n_args) {
     auto args_t = std::make_tuple(args...);
-    strace::UnpackArgs<n_args - 1>(logger, fn, args_t);
+    strace::UnpackArgs<n_args - 1>(logger, fn, args_t, ctx);
   }
   logger << ")";
 }
@@ -281,9 +314,15 @@ void LogSyscallDirect(long retval, std::string_view name, Args... args) {
   logger << name << "(";
   [[maybe_unused]] size_t i = 0;
 
+  strace::SyscallCtx ctx;  // TODO:fixme.
+
   (
-      [&logger, &i, n = sizeof...(args)](auto arg) {
-        strace::PrintArg(arg, arg, logger);
+      [&logger, &i, &ctx, n = sizeof...(args)](auto arg) {
+        if (ctx.arg_strs[i]) {
+          logger << *ctx.arg_strs[i];
+        } else {
+          strace::PrintArg(arg, arg, logger, ctx);
+        }
         if (++i != n) logger << ", ";
       }(args),
       ...);
@@ -300,9 +339,15 @@ void LogSyscallDirect(std::string_view name, Args... args) {
   logger << name << "(";
   [[maybe_unused]] size_t i = 0;
 
+  strace::SyscallCtx ctx;  // TODO:fixme.
+
   (
       [&](auto arg) {
-        strace::PrintArg(arg, arg, logger);
+        if (ctx.arg_strs[i]) {
+          logger << *ctx.arg_strs[i];
+        } else {
+          strace::PrintArg(arg, arg, logger, ctx);
+        }
         if (++i != sizeof...(args)) logger << ", ";
       }(args),
       ...);

--- a/junction/syscall/strace.h
+++ b/junction/syscall/strace.h
@@ -72,10 +72,20 @@ inline void PrintArg(const char *arg, T, rt::Logger &ss) {
   enum class type_name : int {};                  \
   void PrintArg(type_type, type_name, rt::Logger &ss);
 
+extern bool PrintFlagArr(const std::map<int, std::string> &map, int flags,
+                         rt::Logger &ss);
+
+#define DECLARE_STRACE_FLAG_ARR(type_name, type_type, map_name)      \
+  enum class type_name : int {};                                     \
+  extern const std::map<int, std::string> map_name;                  \
+  inline void PrintArg(type_type flags, type_name, rt::Logger &ss) { \
+    PrintFlagArr(map_name, flags, ss);                               \
+  }
+
 DECLARE_STRACE_TYPE(AtFD, int);
 DECLARE_STRACE_TYPE(ProtFlag, int);
-DECLARE_STRACE_TYPE(MMapFlag, int);
-DECLARE_STRACE_TYPE(CloneFlag, unsigned long);
+DECLARE_STRACE_FLAG_ARR(MMapFlag, int, mmap_flags);
+DECLARE_STRACE_FLAG_ARR(CloneFlag, unsigned long, clone_flags);
 DECLARE_STRACE_TYPE(EpollOp, int);
 DECLARE_STRACE_TYPE(OpenFlag, int);
 DECLARE_STRACE_TYPE(SignalNumber, int);
@@ -85,10 +95,12 @@ DECLARE_STRACE_TYPE(IoctlOp, unsigned int)
 DECLARE_STRACE_TYPE(FcntlOp, unsigned int)
 DECLARE_STRACE_TYPE(SocketDomain, int)
 DECLARE_STRACE_TYPE(SocketType, int)
-DECLARE_STRACE_TYPE(MessageFlag, int)
+DECLARE_STRACE_FLAG_ARR(MessageFlag, int, msg_flags);
 DECLARE_STRACE_TYPE(PrctlOp, long)
 DECLARE_STRACE_TYPE(SigProcMaskOp, int)
-DECLARE_STRACE_TYPE(WaitOptions, int);
+DECLARE_STRACE_FLAG_ARR(WaitOptions, int, wait_flags);
+DECLARE_STRACE_FLAG_ARR(StatxMask, unsigned int, statx_mask_flags);
+DECLARE_STRACE_FLAG_ARR(AtFlag, int, at_flags);
 
 void PrintArg(int *fds, FDPair *, rt::Logger &ss);
 
@@ -144,6 +156,20 @@ inline void PrintArg(struct sockaddr *addr, U, rt::Logger &ss) {
 template <typename U>
 inline void PrintArg(cap_user_header_t hdrp, U, rt::Logger &ss) {
   ss << "{" << hdrp->version << ", " << hdrp->pid << "}";
+}
+
+template <typename U>
+inline void PrintArg(struct stat *stat, U, rt::Logger &ss) {
+  ss << "{st_mode=";
+  if ((stat->st_mode & kTypeMask) == kTypeRegularFile) ss << "S_IFREG";
+  if ((stat->st_mode & kTypeMask) == kTypeDirectory) ss << "S_IFDIR";
+  if ((stat->st_mode & kTypeMask) == kTypeCharacter) ss << "S_IFCHR";
+  if ((stat->st_mode & kTypeMask) == kTypeBlock) ss << "S_IFBLK";
+  if ((stat->st_mode & kTypeMask) == kTypeFIFO) ss << "S_IFIFO";
+  if ((stat->st_mode & kTypeMask) == kTypeSocket) ss << "S_IFSOCK";
+  if ((stat->st_mode & kTypeMask) == kTypeSymLink) ss << "S_IFLNK";
+  ss << "|0" << std::oct << (stat->st_mode & kModeMask) << std::dec;
+  ss << ", st_size=" << stat->st_size << "...}";
 }
 
 template <typename U>

--- a/junction/syscall/strace.h
+++ b/junction/syscall/strace.h
@@ -11,6 +11,8 @@
 
 namespace junction {
 
+inline constexpr size_t kMaxEscapedStringLen = 32;
+
 // Log a message that is prefixed with the PID and TID
 #define PLOG(level) \
   LOG(level) << "[" << myproc().get_pid() << ":" << mythread().get_tid() << "] "
@@ -56,6 +58,8 @@ inline void PrintList(const U &array, rt::Logger &ss) {
   ss << "]";
 }
 
+void PrintEscapedString(std::span<const char> str, rt::Logger &ss);
+
 // Default: print any syscall argument using the defined type in usys.h.
 template <typename T, typename U>
 inline void PrintArg(const T arg, const U, rt::Logger &ss,
@@ -67,7 +71,12 @@ inline void PrintArg(const T arg, const U, rt::Logger &ss,
 template <typename U>
 inline void PrintArg(char *arg, U, rt::Logger &ss,
                      [[maybe_unused]] SyscallCtx &ctx) {
-  ss << (void *)arg;
+  if (!arg) {
+    ss << "NULL";
+    return;
+  }
+  std::span<const char> span(arg, strnlen(arg, kMaxEscapedStringLen));
+  PrintEscapedString(span, ss);
 }
 
 // Override: print char *s that are annotated as PathNames.
@@ -77,7 +86,12 @@ void PrintArg(const char *arg, PathName *, rt::Logger &ss, SyscallCtx &ctx);
 template <typename T>
 inline void PrintArg(const char *arg, T, rt::Logger &ss,
                      [[maybe_unused]] SyscallCtx &ctx) {
-  ss << (const void *)arg;
+  if (!arg) {
+    ss << "NULL";
+    return;
+  }
+  std::span<const char> span(arg, strnlen(arg, kMaxEscapedStringLen));
+  PrintEscapedString(span, ss);
 }
 
 #define DECLARE_STRACE_TYPE(type_name, type_type) \
@@ -133,12 +147,12 @@ inline void PrintArg(const std::vector<std::string_view> &arg,
 void PrintArg(const struct sockaddr *addr, rt::Logger &ss);
 
 // void PrintArg(const struct msghdr *msg, rt::Logger &ss);
-void PrintArg(const struct msghdr &msg, rt::Logger &ss);
+void PrintArg(const struct msghdr *msg, rt::Logger &ss, SyscallCtx &ctx);
 
-inline bool PrintArg(const struct mmsghdr &msg, rt::Logger &ss, bool first) {
-  if (!first) ss << ", ";
-  ss << "{msg_len=" << msg.msg_len << ", msg_hdr=";
-  PrintArg(msg.msg_hdr, ss);
+inline bool PrintArg(const struct mmsghdr *msg, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
+  ss << "{msg_len=" << msg->msg_len << ", msg_hdr=";
+  PrintArg(&msg->msg_hdr, ss, ctx);
   ss << "}";
   return true;
 }
@@ -146,13 +160,13 @@ inline bool PrintArg(const struct mmsghdr &msg, rt::Logger &ss, bool first) {
 template <typename U>
 inline void PrintArg(const struct msghdr *msg, U, rt::Logger &ss,
                      [[maybe_unused]] SyscallCtx &ctx) {
-  PrintArg(*msg, ss);
+  PrintArg(msg, ss, ctx);
 }
 
 template <typename U>
 inline void PrintArg(struct msghdr *msg, U, rt::Logger &ss,
                      [[maybe_unused]] SyscallCtx &ctx) {
-  PrintArg(*msg, ss);
+  PrintArg(msg, ss, ctx);
 }
 
 template <typename Logger>
@@ -280,14 +294,31 @@ std::string GetFcntlName(int cmd);
 
 struct ArrayInfo {
   void *ptr;
+  ssize_t size;
+};
+
+struct ByteSpan {
+  const void *ptr;
   size_t size;
 };
 
-bool PrintArg(struct pollfd el, rt::Logger &ss, bool first);
-bool PrintArg(const struct epoll_event el, rt::Logger &ss, bool first);
+bool PrintArg(const struct pollfd *el, rt::Logger &ss, SyscallCtx &ctx);
+bool PrintArg(const struct epoll_event *el, rt::Logger &ss, SyscallCtx &ctx);
+
+inline bool PrintArg(const struct iovec *iov, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
+  ss << "{iov_base=";
+  PrintEscapedString(
+      std::span<const char>(reinterpret_cast<const char *>(iov->iov_base),
+                            iov->iov_len),
+      ss);
+  ss << ", iov_len=" << iov->iov_len << "}";
+  return true;
+}
 
 template <typename U>
-inline void PrintArgSpan(std::span<const U> span, rt::Logger &ss) {
+inline void PrintArgSpan(std::span<const U> span, rt::Logger &ss,
+                         SyscallCtx &ctx) {
   ss << "[";
   int cnt = 0;
   for (const auto &el : span) {
@@ -295,7 +326,8 @@ inline void PrintArgSpan(std::span<const U> span, rt::Logger &ss) {
       ss << ", ...";
       break;
     }
-    if (PrintArg(el, ss, cnt == 0)) cnt++;
+    if (cnt != 0) ss << ", ";
+    if (PrintArg(&el, ss, ctx)) cnt++;
   }
   ss << "]";
 }
@@ -303,9 +335,25 @@ inline void PrintArgSpan(std::span<const U> span, rt::Logger &ss) {
 template <typename T>
 inline void PrintArg(T *, ArrayInfo *arrinfo, rt::Logger &ss,
                      [[maybe_unused]] SyscallCtx &ctx) {
+  if (arrinfo->size <= 0) {
+    ss << "{}";
+    return;
+  }
   // Make a span from the array info
   std::span<const T> span(reinterpret_cast<T *>(arrinfo->ptr), arrinfo->size);
-  PrintArgSpan(span, ss);
+  PrintArgSpan(span, ss, ctx);
+}
+
+template <typename T>
+inline void PrintArg(T *, ByteSpan *binfo, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
+  if (binfo->size <= 0) {
+    return;
+  }
+  // Make a span from the array info
+  std::span<const char> span(reinterpret_cast<const char *>(binfo->ptr),
+                             binfo->size);
+  PrintEscapedString(span, ss);
 }
 
 }  // namespace strace

--- a/junction/syscall/strace.h
+++ b/junction/syscall/strace.h
@@ -23,7 +23,7 @@ struct FDPair {};
 struct SyscallCtx {
   std::tuple<long, long, long, long, long, long> args;
   long sysn;
-  std::optional<std::string> arg_strs[6];
+  std::optional<std::stringstream> arg_strs[6];
   std::optional<long> retval;
 };
 
@@ -94,6 +94,8 @@ extern bool PrintFlagArr(const std::map<int, std::string> &map, int flags,
     PrintFlagArr(map_name, flags, ss);                             \
   }
 
+DECLARE_STRACE_TYPE(SockoptLevel, int);
+
 DECLARE_STRACE_TYPE(AtFD, int);
 DECLARE_STRACE_TYPE(ProtFlag, int);
 DECLARE_STRACE_FLAG_ARR(MMapFlag, int, mmap_flags);
@@ -129,9 +131,8 @@ inline void PrintArg(const std::vector<std::string_view> &arg,
 
 void PrintArg(const struct sockaddr *addr, rt::Logger &ss);
 
-template <typename U>
-inline void PrintArg(struct timespec *t, U, rt::Logger &ss,
-                     [[maybe_unused]] SyscallCtx &ctx) {
+template <typename Logger>
+inline void PrintArg(const struct timespec *t, Logger &ss) {
   if (!t) {
     ss << "NULL";
     return;
@@ -139,7 +140,14 @@ inline void PrintArg(struct timespec *t, U, rt::Logger &ss,
   ss << "{tv_sec=" << t->tv_sec << ", tv_nsec=" << t->tv_nsec << "}";
 }
 
-inline void PrintArg(struct timeval tv, rt::Logger &ss) {
+template <typename U>
+inline void PrintArg(struct timespec *t, U, rt::Logger &ss,
+                     [[maybe_unused]] SyscallCtx &ctx) {
+  PrintArg(t, ss);
+}
+
+template <typename Logger>
+inline void PrintArg(struct timeval tv, Logger &ss) {
   ss << "{tv_sec=" << tv.tv_sec << ", tv_usec=" << tv.tv_usec << "}";
 }
 
@@ -237,9 +245,7 @@ template <int N, typename Ret, typename... UsysArgs, typename ArgT>
 constexpr void UnpackArgs(rt::Logger &ss, Ret (*fn)(UsysArgs...), ArgT &args,
                           SyscallCtx &ctx, bool last = true) {
   if constexpr (N > 0) UnpackArgs<N - 1>(ss, fn, args, ctx, false);
-  if (ctx.arg_strs[N]) {
-    ss << *ctx.arg_strs[N];
-  } else {
+  if (!(ss.absorb(ctx.arg_strs[N]))) {
     using ArgType = std::tuple_element_t<N, std::tuple<UsysArgs...>>;
     PrintArg(((const ArgType)std::get<N>(args)), std::get<N>(args), ss, ctx);
   }
@@ -261,6 +267,10 @@ inline void PrintArgSpan(std::span<const U> span, rt::Logger &ss) {
   ss << "[";
   int cnt = 0;
   for (const auto &el : span) {
+    if (cnt == 2) {
+      ss << ", ...";
+      break;
+    }
     if (PrintArg(el, ss, cnt == 0)) cnt++;
   }
   ss << "]";
@@ -318,11 +328,8 @@ void LogSyscallDirect(long retval, std::string_view name, Args... args) {
 
   (
       [&logger, &i, &ctx, n = sizeof...(args)](auto arg) {
-        if (ctx.arg_strs[i]) {
-          logger << *ctx.arg_strs[i];
-        } else {
+        if (!logger.absorb(ctx.arg_strs[i]))
           strace::PrintArg(arg, arg, logger, ctx);
-        }
         if (++i != n) logger << ", ";
       }(args),
       ...);
@@ -343,11 +350,8 @@ void LogSyscallDirect(std::string_view name, Args... args) {
 
   (
       [&](auto arg) {
-        if (ctx.arg_strs[i]) {
-          logger << *ctx.arg_strs[i];
-        } else {
+        if (!logger.absorb(ctx.arg_strs[i]))
           strace::PrintArg(arg, arg, logger, ctx);
-        }
         if (++i != sizeof...(args)) logger << ", ";
       }(args),
       ...);

--- a/junction/syscall/strace_maps.cc
+++ b/junction/syscall/strace_maps.cc
@@ -35,8 +35,7 @@ extern "C" {
 namespace junction {
 namespace strace {
 
-#define VAL(x) \
-  { x, #x }
+#define VAL(x) {x, #x}
 
 const std::map<int, std::string> protection_flags{
     VAL(PROT_READ),

--- a/junction/syscall/strace_maps.cc
+++ b/junction/syscall/strace_maps.cc
@@ -1,0 +1,548 @@
+#include "junction/syscall/strace_maps.h"
+
+extern "C" {
+#include <fcntl.h>
+#include <linux/futex.h>
+#include <linux/ioctl.h>
+#include <linux/prctl.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sched.h>
+#include <signal.h>
+#include <sys/epoll.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+}
+
+#include <map>
+#include <set>
+
+#ifndef MADV_COLLAPSE
+#define MADV_COLLAPSE 25 /* Synchronous hugepage collapse */
+#endif
+
+#ifndef CLONE_CLEAR_SIGHAND
+#define CLONE_CLEAR_SIGHAND 0x100000000ULL
+#endif
+
+#ifndef CLONE_INTO_CGROUP
+#define CLONE_INTO_CGROUP 0x200000000ULL
+#endif
+
+namespace junction {
+namespace strace {
+
+#define VAL(x) \
+  { x, #x }
+
+const std::map<int, std::string> protection_flags{
+    VAL(PROT_READ),
+    VAL(PROT_WRITE),
+    VAL(PROT_EXEC),
+};
+
+const std::map<int, std::string> mmap_flags{
+    {MAP_SHARED, "MAP_SHARED"},
+    {MAP_PRIVATE, "MAP_PRIVATE"},
+    {MAP_ANONYMOUS, "MAP_ANONYMOUS"},
+    {MAP_FIXED, "MAP_FIXED"},
+    {MAP_FIXED_NOREPLACE, "MAP_FIXED_NOREPLACE"},
+    {MAP_GROWSDOWN, "MAP_GROWSDOWN"},
+    {MAP_HUGETLB, "MAP_HUGETLB"},
+    {MAP_LOCKED, "MAP_LOCKED"},
+    {MAP_NONBLOCK, "MAP_NONBLOCK"},
+    {MAP_NORESERVE, "MAP_NORESERVE"},
+    {MAP_POPULATE, "MAP_POPULATE"},
+    {MAP_STACK, "MAP_STACK"},
+};
+
+const std::map<int, std::string> open_flags{
+    {O_APPEND, "O_APPEND"},
+    {O_ASYNC, "O_ASYNC"},
+    {O_CLOEXEC, "O_CLOEXEC"},
+    {O_CREAT, "O_CREAT"},
+    {O_DIRECT, "O_DIRECT"},
+    {O_DIRECTORY, "O_DIRECTORY"},
+    {O_DSYNC, "O_DSYNC"},
+    {O_EXCL, "O_EXCL"},
+    {O_LARGEFILE, "O_LARGEFILE"},
+    {O_NOATIME, "O_NOATIME"},
+    {O_NOCTTY, "O_NOCTTY"},
+    {O_NOFOLLOW, "O_NOFOLLOW"},
+    {O_NONBLOCK, "O_NONBLOCK"},
+    {O_PATH, "O_PATH"},
+    {O_SYNC, "O_SYNC"},
+    {O_TRUNC, "O_TRUNC"},
+    {O_WRONLY, "O_WRONLY"},
+    {O_RDWR, "O_RDWR"},
+    {(O_TMPFILE & ~O_DIRECTORY), "O_TMPFILE"}};
+
+const std::map<int, std::string> madvise_hints{
+    {MADV_NORMAL, "MADV_NORMAL"},
+    {MADV_DONTNEED, "MADV_DONTNEED"},
+    {MADV_RANDOM, "MADV_RANDOM"},
+    {MADV_REMOVE, "MADV_REMOVE"},
+    {MADV_SEQUENTIAL, "MADV_SEQUENTIAL"},
+    {MADV_DONTFORK, "MADV_DONTFORK"},
+    {MADV_WILLNEED, "MADV_WILLNEED"},
+    {MADV_DOFORK, "MADV_DOFORK"},
+    {MADV_HUGEPAGE, "MADV_HUGEPAGE"},
+    {MADV_HWPOISON, "MADV_HWPOISON"},
+    {MADV_NOHUGEPAGE, "MADV_NOHUGEPAGE"},
+    {MADV_MERGEABLE, "MADV_MERGEABLE"},
+    {MADV_COLLAPSE, "MADV_COLLAPSE"},
+    {MADV_UNMERGEABLE, "MADV_UNMERGEABLE"},
+    {MADV_DONTDUMP, "MADV_DONTDUMP"},
+    {MADV_DODUMP, "MADV_DODUMP"},
+    {MADV_FREE, "MADV_FREE"},
+    {MADV_WIPEONFORK, "MADV_WIPEONFORK"},
+    {MADV_COLD, "MADV_COLD"},
+    {MADV_PAGEOUT, "MADV_PAGEOUT"},
+    {MADV_POPULATE_READ, "MADV_POPULATE_READ"},
+    {MADV_POPULATE_WRITE, "MADV_POPULATE_WRITE"},
+};
+
+const std::map<int, std::string> clone_flags{
+    {CLONE_CHILD_CLEARTID, "CLONE_CHILD_CLEARTID"},
+    {CLONE_CHILD_SETTID, "CLONE_CHILD_SETTID"},
+    {CLONE_CLEAR_SIGHAND, "CLONE_CLEAR_SIGHAND"},
+    {CLONE_DETACHED, "CLONE_DETACHED"},
+    {CLONE_FILES, "CLONE_FILES"},
+    {CLONE_FS, "CLONE_FS"},
+    {CLONE_INTO_CGROUP, "CLONE_INTO_CGROUP"},
+    {CLONE_IO, "CLONE_IO"},
+    {CLONE_NEWCGROUP, "CLONE_NEWCGROUP"},
+    {CLONE_NEWIPC, "CLONE_NEWIPC"},
+    {CLONE_NEWNET, "CLONE_NEWNET"},
+    {CLONE_NEWNS, "CLONE_NEWNS"},
+    {CLONE_NEWPID, "CLONE_NEWPID"},
+    {CLONE_NEWUSER, "CLONE_NEWUSER"},
+    {CLONE_NEWUTS, "CLONE_NEWUTS"},
+    {CLONE_PARENT, "CLONE_PARENT"},
+    {CLONE_PARENT_SETTID, "CLONE_PARENT_SETTID"},
+    {CLONE_PIDFD, "CLONE_PIDFD"},
+    {CLONE_PTRACE, "CLONE_PTRACE"},
+    {CLONE_SETTLS, "CLONE_SETTLS"},
+    {CLONE_SIGHAND, "CLONE_SIGHAND"},
+    {CLONE_SYSVSEM, "CLONE_SYSVSEM"},
+    {CLONE_THREAD, "CLONE_THREAD"},
+    {CLONE_UNTRACED, "CLONE_UNTRACED"},
+    {CLONE_VFORK, "CLONE_VFORK"},
+    {CLONE_VM, "CLONE_VM"},
+};
+
+const std::map<int, std::string> futex_flags{
+    {FUTEX_WAKE_BITSET, "FUTEX_WAKE_BITSET"},
+    {FUTEX_WAIT, "FUTEX_WAIT"},
+    {FUTEX_WAKE, "FUTEX_WAKE"},
+    {FUTEX_FD, "FUTEX_FD"},
+    {FUTEX_REQUEUE, "FUTEX_REQUEUE"},
+    {FUTEX_CMP_REQUEUE, "FUTEX_CMP_REQUEUE"},
+    {FUTEX_WAKE_OP, "FUTEX_WAKE_OP"},
+    {FUTEX_WAIT_BITSET, "FUTEX_WAIT_BITSET"},
+    {FUTEX_LOCK_PI, "FUTEX_LOCK_PI"},
+    {FUTEX_LOCK_PI2, "FUTEX_LOCK_PI2"},
+    {FUTEX_TRYLOCK_PI, "FUTEX_TRYLOCK_PI"},
+    {FUTEX_UNLOCK_PI, "FUTEX_UNLOCK_PI"},
+    {FUTEX_CMP_REQUEUE_PI, "FUTEX_CMP_REQUEUE_PI"},
+    {FUTEX_WAIT_REQUEUE_PI, "FUTEX_WAIT_REQUEUE_PI"},
+};
+
+const std::set<int> futex_ops_with_val2{FUTEX_CMP_REQUEUE, FUTEX_WAKE_OP,
+                                        FUTEX_CMP_REQUEUE_PI};
+
+const std::set<int> futex_ops_with_timeout{FUTEX_WAIT, FUTEX_WAIT_BITSET,
+                                           FUTEX_LOCK_PI, FUTEX_LOCK_PI2,
+                                           FUTEX_WAIT_REQUEUE_PI};
+
+const std::map<int, std::string> ioctls{
+    VAL(TCGETS), VAL(TCSETS), VAL(TCSETSW), VAL(TCSETSF), VAL(TCGETA),
+    VAL(TCSETA), VAL(TCSETAW), VAL(TCSETAF), VAL(TCSBRK), VAL(TCXONC),
+    VAL(TCFLSH), VAL(TIOCEXCL), VAL(TIOCNXCL), VAL(TIOCSCTTY), VAL(TIOCGPGRP),
+    VAL(TIOCSPGRP), VAL(TIOCOUTQ), VAL(TIOCSTI), VAL(TIOCGWINSZ),
+    VAL(TIOCSWINSZ), VAL(TIOCMGET), VAL(TIOCMBIS), VAL(TIOCMBIC), VAL(TIOCMSET),
+    VAL(TIOCGSOFTCAR), VAL(TIOCSSOFTCAR), VAL(FIONREAD), VAL(TIOCINQ),
+    VAL(TIOCLINUX), VAL(TIOCCONS), VAL(TIOCGSERIAL), VAL(TIOCSSERIAL),
+    VAL(TIOCPKT), VAL(FIONBIO), VAL(TIOCNOTTY), VAL(TIOCSETD), VAL(TIOCGETD),
+    VAL(TCSBRKP), VAL(TIOCSBRK), VAL(TIOCCBRK), VAL(TIOCGSID),
+    // VAL(TCGETS2), VAL(TCSETS2), VAL(TCSETSW2), VAL(TCSETSF2),
+    VAL(TIOCGRS485), VAL(TIOCSRS485), VAL(TIOCGPTN), VAL(TIOCSPTLCK),
+    VAL(TCGETX), VAL(TCSETX), VAL(TCSETXF), VAL(TCSETXW), VAL(FIONCLEX),
+    VAL(FIOCLEX), VAL(FIOASYNC), VAL(TIOCSERCONFIG), VAL(TIOCSERGWILD),
+    VAL(TIOCSERSWILD), VAL(TIOCGLCKTRMIOS), VAL(TIOCSLCKTRMIOS),
+    VAL(TIOCSERGSTRUCT), VAL(TIOCSERGETLSR), VAL(TIOCSERGETMULTI),
+    VAL(TIOCSERSETMULTI), VAL(TIOCMIWAIT), VAL(TIOCGICOUNT),
+    // VAL(TIOCGHAYESESP), VAL(TIOCSHAYESESP),
+    VAL(TIOCPKT_DATA), VAL(TIOCPKT_FLUSHREAD), VAL(TIOCPKT_FLUSHWRITE),
+    VAL(TIOCPKT_STOP), VAL(TIOCPKT_START), VAL(TIOCPKT_NOSTOP),
+    VAL(TIOCPKT_DOSTOP), VAL(TIOCSER_TEMT), VAL(TIOCGPTPEER)};
+
+const std::map<int, std::string> fcntls{
+    VAL(F_DUPFD),
+    VAL(F_DUPFD_CLOEXEC),
+    VAL(F_GETFD),
+    VAL(F_SETFD),
+    VAL(F_GETFL),
+    VAL(F_SETFL),
+    VAL(F_SETLK),
+    VAL(F_SETLKW),
+    VAL(F_GETLK),
+    VAL(F_OFD_SETLK),
+    VAL(F_OFD_SETLKW),
+    VAL(F_OFD_GETLK),
+    VAL(F_GETOWN),
+    VAL(F_SETOWN),
+    VAL(F_GETOWN_EX),
+    VAL(F_SETOWN_EX),
+    VAL(F_GETSIG),
+    VAL(F_SETSIG),
+    VAL(F_SETLEASE),
+    VAL(F_GETLEASE),
+    VAL(F_NOTIFY),
+    VAL(F_SETPIPE_SZ),
+    VAL(F_GETPIPE_SZ),
+    VAL(F_ADD_SEALS),
+    VAL(F_GET_SEALS),
+    VAL(F_GET_RW_HINT),
+    VAL(F_SET_RW_HINT),
+    VAL(F_GET_FILE_RW_HINT),
+    VAL(F_SET_FILE_RW_HINT),
+};
+
+const std::map<int, std::string> statx_mask_flags{
+    VAL(STATX_TYPE),
+    VAL(STATX_MODE),
+    VAL(STATX_NLINK),
+    VAL(STATX_UID),
+    VAL(STATX_GID),
+    VAL(STATX_ATIME),
+    VAL(STATX_MTIME),
+    VAL(STATX_CTIME),
+    VAL(STATX_INO),
+    VAL(STATX_SIZE),
+    VAL(STATX_BLOCKS),
+    VAL(STATX_BASIC_STATS),
+    // VAL(STATX_ALL), // same as STATX_BASIC_STATS | STATX_BTIME
+    VAL(STATX_BTIME),
+    VAL(STATX_MNT_ID),
+    VAL(STATX_DIOALIGN),
+};
+
+const std::map<int, std::string> at_flags{
+    VAL(AT_SYMLINK_NOFOLLOW),
+    VAL(AT_REMOVEDIR),
+    VAL(AT_SYMLINK_FOLLOW),
+    VAL(AT_NO_AUTOMOUNT),
+    VAL(AT_EMPTY_PATH),
+    VAL(AT_STATX_SYNC_TYPE),
+    VAL(AT_STATX_SYNC_AS_STAT),
+    VAL(AT_STATX_FORCE_SYNC),
+    VAL(AT_STATX_DONT_SYNC),
+    VAL(AT_RECURSIVE),
+    VAL(AT_EACCESS),
+};
+
+const std::map<int, std::string> poll_flags{
+    VAL(POLLIN),     VAL(POLLPRI),    VAL(POLLOUT),    VAL(POLLRDHUP),
+    VAL(POLLERR),    VAL(POLLHUP),    VAL(POLLNVAL),   VAL(POLLRDNORM),
+    VAL(POLLRDBAND), VAL(POLLWRNORM), VAL(POLLWRBAND), VAL(POLLMSG)};
+
+const std::map<int, std::string> prctl_ops{
+    VAL(PR_CAP_AMBIENT),
+    VAL(PR_CAPBSET_READ),
+    VAL(PR_CAPBSET_DROP),
+    VAL(PR_SET_CHILD_SUBREAPER),
+    VAL(PR_GET_CHILD_SUBREAPER),
+    VAL(PR_SET_DUMPABLE),
+    VAL(PR_GET_DUMPABLE),
+    VAL(PR_SET_ENDIAN),
+    VAL(PR_GET_ENDIAN),
+    VAL(PR_SET_FP_MODE),
+    VAL(PR_GET_FP_MODE),
+    VAL(PR_SET_FPEMU),
+    VAL(PR_GET_FPEMU),
+    VAL(PR_SET_FPEXC),
+    VAL(PR_GET_FPEXC),
+    VAL(PR_SET_IO_FLUSHER),
+    VAL(PR_GET_IO_FLUSHER),
+    VAL(PR_SET_KEEPCAPS),
+    VAL(PR_GET_KEEPCAPS),
+    VAL(PR_MCE_KILL),
+    VAL(PR_MCE_KILL_GET),
+    VAL(PR_SET_MM),
+    VAL(PR_SET_VMA),
+    VAL(PR_MPX_ENABLE_MANAGEMENT),
+    VAL(PR_MPX_DISABLE_MANAGEMENT),
+    VAL(PR_SET_NAME),
+    VAL(PR_GET_NAME),
+    VAL(PR_SET_NO_NEW_PRIVS),
+    VAL(PR_GET_NO_NEW_PRIVS),
+    VAL(PR_PAC_RESET_KEYS),
+    VAL(PR_SET_PDEATHSIG),
+    VAL(PR_GET_PDEATHSIG),
+    VAL(PR_SET_PTRACER),
+    VAL(PR_SET_SECCOMP),
+    VAL(PR_GET_SECCOMP),
+    VAL(PR_SET_SECUREBITS),
+    VAL(PR_GET_SECUREBITS),
+    VAL(PR_GET_SPECULATION_CTRL),
+    VAL(PR_SET_SPECULATION_CTRL),
+    VAL(PR_SVE_SET_VL),
+    VAL(PR_SVE_GET_VL),
+    VAL(PR_SET_SYSCALL_USER_DISPATCH),
+    VAL(PR_SET_TAGGED_ADDR_CTRL),
+    VAL(PR_GET_TAGGED_ADDR_CTRL),
+    VAL(PR_TASK_PERF_EVENTS_DISABLE),
+    VAL(PR_TASK_PERF_EVENTS_ENABLE),
+    VAL(PR_SET_THP_DISABLE),
+    VAL(PR_GET_THP_DISABLE),
+    VAL(PR_GET_TID_ADDRESS),
+    VAL(PR_SET_TIMERSLACK),
+    VAL(PR_GET_TIMERSLACK),
+    VAL(PR_SET_TIMING),
+    VAL(PR_GET_TIMING),
+    VAL(PR_SET_TSC),
+    VAL(PR_GET_TSC),
+    VAL(PR_SET_UNALIGN),
+    VAL(PR_GET_UNALIGN),
+    VAL(PR_GET_AUXV),
+    VAL(PR_SET_MDWE),
+    VAL(PR_GET_MDWE),
+};
+
+const std::map<int, std::string> sock_domains{
+    VAL(AF_UNIX),   VAL(AF_LOCAL),     VAL(AF_INET),    VAL(AF_AX25),
+    VAL(AF_IPX),    VAL(AF_APPLETALK), VAL(AF_X25),     VAL(AF_INET6),
+    VAL(AF_DECnet), VAL(AF_KEY),       VAL(AF_NETLINK), VAL(AF_PACKET),
+    VAL(AF_RDS),    VAL(AF_PPPOX),     VAL(AF_LLC),     VAL(AF_IB),
+    VAL(AF_MPLS),   VAL(AF_CAN),       VAL(AF_TIPC),    VAL(AF_BLUETOOTH),
+    VAL(AF_ALG),    VAL(AF_VSOCK),     VAL(AF_KCM),     VAL(AF_XDP),
+};
+
+const std::map<int, std::string> sock_types{
+    VAL(SOCK_STREAM), VAL(SOCK_DGRAM), VAL(SOCK_SEQPACKET),
+    VAL(SOCK_RAW),    VAL(SOCK_RDM),   VAL(SOCK_PACKET),
+};
+
+const std::map<int, std::string> msg_flags{
+    VAL(MSG_CMSG_CLOEXEC), VAL(MSG_DONTWAIT), VAL(MSG_ERRQUEUE),
+    VAL(MSG_OOB),          VAL(MSG_PEEK),     VAL(MSG_TRUNC),
+    VAL(MSG_WAITALL),      VAL(MSG_CONFIRM),  VAL(MSG_DONTROUTE),
+    VAL(MSG_EOR),          VAL(MSG_MORE),     VAL(MSG_NOSIGNAL),
+    VAL(MSG_OOB),
+};
+
+const std::map<int, std::string> epoll_ctl_ops{
+    VAL(EPOLL_CTL_ADD), VAL(EPOLL_CTL_MOD), VAL(EPOLL_CTL_DEL)};
+
+const char *sigmap[] = {
+    "SIGHUP",  "SIGINT",    "SIGQUIT", "SIGILL",    "SIGTRAP", "SIGABRT",
+    "SIGBUS",  "SIGFPE",    "SIGKILL", "SIGUSR1",   "SIGSEGV", "SIGUSR2",
+    "SIGPIPE", "SIGALRM",   "SIGTERM", "SIGSTKFLT", "SIGCHLD", "SIGCONT",
+    "SIGSTOP", "SIGTSTP",   "SIGTTIN", "SIGTTOU",   "SIGURG",  "SIGXCPU",
+    "SIGXFSZ", "SIGVTALRM", "SIGPROF", "SIGWINCH",  "SIGIO",   "SIGPWR",
+    "SIGSYS",  "SIGUNUSED"};
+
+const std::map<int, std::string> sigprocmask_how{
+    VAL(SIG_BLOCK), VAL(SIG_UNBLOCK), VAL(SIG_SETMASK)};
+
+const std::map<int, std::string> wait_flags = {
+    VAL(WEXITED), VAL(WSTOPPED),  VAL(WCONTINUED), VAL(WNOHANG),
+    VAL(WNOWAIT), VAL(WUNTRACED), VAL(WCONTINUED),
+};
+
+const std::map<int, std::string> sockopt_levels = {
+    VAL(SOL_SOCKET),   VAL(IPPROTO_IP),  VAL(IPPROTO_TCP), VAL(IPPROTO_UDP),
+    VAL(IPPROTO_IPV6), VAL(IPPROTO_RAW), VAL(SOL_NETLINK),
+};
+
+const std::map<int, std::string> sock_options = {
+    VAL(SO_DEBUG),
+    VAL(SO_REUSEADDR),
+    VAL(SO_TYPE),
+    VAL(SO_ERROR),
+    VAL(SO_DONTROUTE),
+    VAL(SO_BROADCAST),
+    VAL(SO_SNDBUF),
+    VAL(SO_RCVBUF),
+    VAL(SO_KEEPALIVE),
+    VAL(SO_OOBINLINE),
+    VAL(SO_NO_CHECK),
+    VAL(SO_PRIORITY),
+    VAL(SO_LINGER),
+    VAL(SO_BSDCOMPAT),
+    VAL(SO_REUSEPORT),
+    VAL(SO_PASSCRED),
+    VAL(SO_PEERCRED),
+    VAL(SO_RCVLOWAT),
+    VAL(SO_SNDLOWAT),
+    VAL(SO_RCVTIMEO),
+    VAL(SO_SNDTIMEO),
+    VAL(SO_SECURITY_AUTHENTICATION),
+    VAL(SO_SECURITY_ENCRYPTION_TRANSPORT),
+    VAL(SO_SECURITY_ENCRYPTION_NETWORK),
+    VAL(SO_BINDTODEVICE),
+    VAL(SO_DETACH_FILTER),
+    VAL(SO_PEERNAME),
+    VAL(SO_TIMESTAMP_OLD),
+    VAL(SO_ACCEPTCONN),
+    VAL(SO_PEERSEC),
+    VAL(SO_SNDBUFFORCE),
+    VAL(SO_RCVBUFFORCE),
+    VAL(SO_PASSSEC),
+    VAL(SO_TIMESTAMPNS_OLD),
+    VAL(SO_MARK),
+    VAL(SO_TIMESTAMPING_OLD),
+    VAL(SO_PROTOCOL),
+    VAL(SO_DOMAIN),
+    VAL(SO_RXQ_OVFL),
+    VAL(SO_WIFI_STATUS),
+    VAL(SO_PEEK_OFF),
+    VAL(SO_NOFCS),
+    VAL(SO_LOCK_FILTER),
+    VAL(SO_SELECT_ERR_QUEUE),
+    VAL(SO_BUSY_POLL),
+    VAL(SO_MAX_PACING_RATE),
+    VAL(SO_BPF_EXTENSIONS),
+    VAL(SO_INCOMING_CPU),
+    VAL(SO_ATTACH_BPF),
+    VAL(SO_ATTACH_REUSEPORT_CBPF),
+    VAL(SO_ATTACH_REUSEPORT_EBPF),
+    VAL(SO_CNX_ADVICE),
+    VAL(SO_MEMINFO),
+    VAL(SO_INCOMING_NAPI_ID),
+    VAL(SO_COOKIE),
+    VAL(SO_PEERGROUPS),
+    VAL(SO_ZEROCOPY),
+    VAL(SO_TXTIME),
+    VAL(SO_BINDTOIFINDEX),
+    VAL(SO_TIMESTAMP_NEW),
+    VAL(SO_TIMESTAMPNS_NEW),
+    VAL(SO_TIMESTAMPING_NEW),
+    VAL(SO_RCVTIMEO_NEW),
+    VAL(SO_SNDTIMEO_NEW),
+    VAL(SO_DETACH_REUSEPORT_BPF),
+    VAL(SO_PREFER_BUSY_POLL),
+    VAL(SO_BUSY_POLL_BUDGET),
+    VAL(SO_NETNS_COOKIE),
+    VAL(SO_BUF_LOCK),
+    VAL(SO_RESERVE_MEM),
+    VAL(SO_TXREHASH),
+    VAL(SO_RCVMARK),
+    VAL(SO_PASSPIDFD),
+    VAL(SO_PEERPIDFD),
+    // VAL(SO_RCVPRIORITY),
+    // VAL(SO_PASSRIGHTS),
+    // VAL(SO_INQ),
+};
+
+const std::set<int> intlike_sockopts = {
+    SO_DEBUG,
+    SO_REUSEADDR,
+    SO_DONTROUTE,
+    SO_BROADCAST,
+    SO_SNDBUF,
+    SO_RCVBUF,
+    SO_KEEPALIVE,
+    SO_OOBINLINE,
+    SO_NO_CHECK,
+    SO_PRIORITY,
+    SO_BSDCOMPAT,
+    SO_REUSEPORT,
+    SO_PASSCRED,
+    SO_RCVLOWAT,
+    SO_SNDLOWAT,
+    SO_DETACH_FILTER,
+    SO_TIMESTAMP_OLD,
+    SO_ACCEPTCONN,
+    SO_SNDBUFFORCE,
+    SO_RCVBUFFORCE,
+    SO_PASSSEC,
+    SO_TIMESTAMPNS_OLD,
+    SO_MARK,
+    SO_TIMESTAMPING_OLD,
+    SO_RXQ_OVFL,
+    SO_WIFI_STATUS,
+    SO_PEEK_OFF,
+    SO_NOFCS,
+    SO_LOCK_FILTER,
+    SO_SELECT_ERR_QUEUE,
+    SO_BUSY_POLL,
+    SO_INCOMING_CPU,
+    SO_CNX_ADVICE,
+    SO_INCOMING_NAPI_ID,
+    SO_ZEROCOPY,
+    SO_TIMESTAMP_NEW,
+    SO_TIMESTAMPNS_NEW,
+    SO_TIMESTAMPING_NEW,
+    SO_DETACH_REUSEPORT_BPF,
+    SO_PREFER_BUSY_POLL,
+    SO_BUSY_POLL_BUDGET,
+    SO_RESERVE_MEM,
+    SO_RCVMARK,
+    SO_PASSPIDFD,
+    // SO_RCVPRIORITY,
+    // SO_PASSRIGHTS,
+    // SO_INQ
+};
+
+const std::map<int, std::string> ip_options = {VAL(IP_ADD_MEMBERSHIP),
+                                               VAL(IP_ADD_SOURCE_MEMBERSHIP),
+                                               VAL(IP_BIND_ADDRESS_NO_PORT),
+                                               VAL(IP_BLOCK_SOURCE),
+                                               VAL(IP_DROP_MEMBERSHIP),
+                                               VAL(IP_DROP_SOURCE_MEMBERSHIP),
+                                               VAL(IP_FREEBIND),
+                                               VAL(IP_HDRINCL),
+                                               VAL(IP_LOCAL_PORT_RANGE),
+                                               VAL(IP_MSFILTER),
+                                               VAL(IP_MTU),
+                                               VAL(IP_MTU_DISCOVER),
+                                               VAL(IP_MULTICAST_ALL),
+                                               VAL(IP_MULTICAST_IF),
+                                               VAL(IP_MULTICAST_LOOP),
+                                               VAL(IP_MULTICAST_TTL),
+                                               VAL(IP_NODEFRAG),
+                                               VAL(IP_OPTIONS),
+                                               VAL(IP_PASSSEC),
+                                               VAL(IP_PKTINFO),
+                                               VAL(IP_RECVERR),
+                                               VAL(IP_RECVOPTS),
+                                               VAL(IP_RECVORIGDSTADDR),
+                                               VAL(IP_RECVTOS),
+                                               VAL(IP_RECVTTL),
+                                               VAL(IP_RETOPTS),
+                                               VAL(IP_ROUTER_ALERT),
+                                               VAL(IP_TOS),
+                                               VAL(IP_TRANSPARENT),
+                                               VAL(IP_TTL),
+                                               VAL(IP_UNBLOCK_SOURCE)};
+
+// Options that take an integer pointer as optval
+const std::set<int> ip_int_options = {IP_FREEBIND,
+                                      IP_HDRINCL,
+                                      IP_LOCAL_PORT_RANGE,
+                                      IP_MTU,
+                                      IP_MTU_DISCOVER,
+                                      IP_MULTICAST_ALL,
+                                      IP_MULTICAST_LOOP,
+                                      IP_MULTICAST_TTL,
+                                      IP_NODEFRAG,
+                                      IP_PASSSEC,
+                                      IP_PKTINFO,
+                                      IP_RECVERR,
+                                      IP_RECVOPTS,
+                                      IP_RECVORIGDSTADDR,
+                                      IP_RECVTOS,
+                                      IP_RECVTTL,
+                                      IP_RETOPTS,
+                                      IP_ROUTER_ALERT,
+                                      IP_TOS,
+                                      IP_TRANSPARENT,
+                                      IP_TTL};
+
+}  // namespace strace
+}  // namespace junction

--- a/junction/syscall/strace_maps.h
+++ b/junction/syscall/strace_maps.h
@@ -1,0 +1,44 @@
+// strace_maps.h - constant maps and sets for strace functionality
+
+#pragma once
+
+#include <map>
+#include <set>
+#include <string>
+
+namespace junction {
+namespace strace {
+
+// Forward declarations for all const maps and sets
+extern const std::map<int, std::string> protection_flags;
+extern const std::map<int, std::string> mmap_flags;
+extern const std::map<int, std::string> open_flags;
+extern const std::map<int, std::string> madvise_hints;
+extern const std::map<int, std::string> clone_flags;
+extern const std::map<int, std::string> futex_flags;
+extern const std::set<int> futex_ops_with_val2;
+extern const std::set<int> futex_ops_with_timeout;
+extern const std::map<int, std::string> ioctls;
+extern const std::map<int, std::string> fcntls;
+extern const std::map<int, std::string> statx_mask_flags;
+extern const std::map<int, std::string> at_flags;
+extern const std::map<int, std::string> poll_flags;
+extern const std::map<int, std::string> prctl_ops;
+extern const std::map<int, std::string> sock_domains;
+extern const std::map<int, std::string> sock_types;
+extern const std::map<int, std::string> msg_flags;
+extern const std::map<int, std::string> epoll_ctl_ops;
+extern const std::map<int, std::string> sigprocmask_how;
+extern const std::map<int, std::string> wait_flags;
+extern const std::map<int, std::string> sockopt_levels;
+extern const std::map<int, std::string> sock_options;
+extern const std::set<int> intlike_sockopts;
+extern const std::map<int, std::string> ip_options;
+extern const std::set<int> ip_int_options;
+
+// Signal map array
+extern const char *sigmap[];
+constexpr size_t kNumSignals = 32;
+
+}  // namespace strace
+}  // namespace junction

--- a/junction/syscall/systbl.py
+++ b/junction/syscall/systbl.py
@@ -167,7 +167,7 @@ def genLogSyscallCall(pretty_name, with_ret, fnname):
         else:
             ret = "ret, "
 
-    fn += f"\n\t\tLogSyscall({ret}\"{pretty_name}\", &{fnname},"
+    fn += f"\n\t\tLogSyscall(ctx, {ret}\"{pretty_name}\", &{fnname},"
     for i in range(6):
         if (pretty_name, i) in ARRAY_ARGS:
             fn += f"\n\t\t\t(&arrinfo{i})"
@@ -182,15 +182,18 @@ def genLogSyscallCall(pretty_name, with_ret, fnname):
     return fn
 
 
-def emit_strace_target(pretty_name, function_name, output):
+def emit_strace_target(pretty_name, function_name, output, sysnr):
     fn = f"\nextern \"C\" __attribute__((cold)) int64_t {function_name}_trace(int64_t arg0, int64_t arg1, int64_t arg2, int64_t arg3, int64_t arg4, int64_t arg5) {'{'}"
     fn += "\n\tassert_stack_is_aligned();"
+    fn += f"\n\tstrace::SyscallCtx ctx(std::make_tuple(arg0, arg1, arg2, arg3, arg4, arg5), {sysnr});"
     runsyscall_cmd = f"\n\tint64_t ret = reinterpret_cast<sysfn_t>(&{function_name})(arg0, arg1, arg2, arg3, arg4, arg5);"
 
     if STRACE_LOG_BEFORE_RETURN:
         fn += genLogSyscallCall(pretty_name, False, function_name)
 
     fn += runsyscall_cmd
+
+    fn += f"\n\tctx.retval = ret;"
 
     if STRACE_LOG_AFTER_RETURN:
         fn += genLogSyscallCall(pretty_name, True, function_name)
@@ -363,7 +366,7 @@ with open(USYS_LIST) as f:
         systabl_targets[sysnr] = target
         if name not in SKIP_STRACE_TARGET:
             systabl_strace_targets[sysnr] = emit_strace_target(
-                name, target, dispatch_file)
+                name, target, dispatch_file, sysnr)
         else:
             systabl_strace_targets[sysnr] = target
 
@@ -374,7 +377,7 @@ for i in range(SYS_NR):
     name = syscall_nr_to_name.get(i, f"SYS_{i}")
     target = emit_enosys_target(name, i, dispatch_file)
     systabl_targets[i] = target
-    systabl_strace_targets[i] = emit_strace_target(name, target, dispatch_file)
+    systabl_strace_targets[i] = emit_strace_target(name, target, dispatch_file, i)
 
 
 # generate the sysfn table

--- a/junction/syscall/systbl.py
+++ b/junction/syscall/systbl.py
@@ -130,6 +130,13 @@ SKIP_STRACE_TARGET = [
     "clone3",
     "rt_sigreturn"]
 
+ARRAY_ARGS = {
+    ("poll", 0) : 1,
+    ("epoll_wait", 1) : 2,
+    ("epoll_pwait", 1) : 2,
+    ("epoll_pwait2", 1) : 2,
+}
+
 systabl_targets = [None for i in range(SYS_NR)]
 systabl_strace_targets = [None for i in range(SYS_NR)]
 
@@ -142,23 +149,32 @@ systabl_targets[455] = "junction_fncall_stackswitch_enter_eax"
 for i in range(451, 456):
     systabl_strace_targets[i] = systabl_targets[i]
 
-
 def genLogSyscallCall(pretty_name, with_ret, fnname):
     ret = ""
+
+    fn = "\n\t{"
+    for i in range(6):
+        if (pretty_name, i) in ARRAY_ARGS:
+            fn += f"\n\t\tstrace::ArrayInfo arrinfo{i} = {{reinterpret_cast<void *>(arg{i}), static_cast<size_t>(arg{ARRAY_ARGS[(pretty_name, i)]})}};"
+
     if with_ret:
         if (pretty_name, -1) in TYPE_ARR:
             ret = f"{TYPE_ARR[(pretty_name, -1)]}(ret), "
         else:
             ret = "ret, "
-    fn = f"\n\tLogSyscall({ret}\"{pretty_name}\", &{fnname},"
+
+    fn += f"\n\t\tLogSyscall({ret}\"{pretty_name}\", &{fnname},"
     for i in range(6):
-        if (pretty_name, i) not in TYPE_ARR:
-            fn += f"\n\t\t(arg{i})"
+        if (pretty_name, i) in ARRAY_ARGS:
+            fn += f"\n\t\t\t(&arrinfo{i})"
+        elif (pretty_name, i) not in TYPE_ARR:
+            fn += f"\n\t\t\t(arg{i})"
         else:
-            fn += f"\n\t\t{TYPE_ARR[(pretty_name, i)]}(arg{i})"
+            fn += f"\n\t\t\t{TYPE_ARR[(pretty_name, i)]}(arg{i})"
         if i < 5:
             fn += ","
     fn += ");"
+    fn += "\n\t}"
     return fn
 
 

--- a/junction/syscall/systbl.py
+++ b/junction/syscall/systbl.py
@@ -142,6 +142,24 @@ ARRAY_ARGS = {
     ("epoll_pwait", 1) : 2,
     ("epoll_pwait2", 1) : 2,
     ("recvmmsg", 1) : 2,
+    ("writev", 1) : 2,
+    ("readv", 1) : 2,
+    ("pwritev", 1) : 2,
+    ("pwritev2", 1) : 2,
+    ("preadv", 1) : 2,
+}
+
+BYTE_SPAN_ARGS = {
+    ("read", 1): 2,
+    ("write", 1) : 2,
+    ("pread64", 1) : 2,
+    ("pwrite64", 1) : 2,
+    ("pread", 1) : 2,
+    ("pwrite", 1) : 2,
+    ("recv", 1): 2,
+    ("recvfrom", 1): 2,
+    ("send", 1): 2,
+    ("sendto", 1): 2,
 }
 
 systabl_targets = [None for i in range(SYS_NR)]
@@ -162,7 +180,9 @@ def genLogSyscallCall(pretty_name, with_ret, fnname):
     fn = "\n\t{"
     for i in range(6):
         if (pretty_name, i) in ARRAY_ARGS:
-            fn += f"\n\t\tstrace::ArrayInfo arrinfo{i} = {{reinterpret_cast<void *>(arg{i}), static_cast<size_t>(arg{ARRAY_ARGS[(pretty_name, i)]})}};"
+            fn += f"\n\t\tstrace::ArrayInfo arrinfo{i} = {{reinterpret_cast<void *>(arg{i}), static_cast<ssize_t>(arg{ARRAY_ARGS[(pretty_name, i)]})}};"
+        elif (pretty_name, i) in BYTE_SPAN_ARGS:
+            fn += f"\n\t\tstrace::ByteSpan binfo{i} = {{reinterpret_cast<void *>(arg{i}), static_cast<size_t>(arg{BYTE_SPAN_ARGS[(pretty_name, i)]})}};"
 
     if with_ret:
         if (pretty_name, -1) in TYPE_ARR:
@@ -174,6 +194,8 @@ def genLogSyscallCall(pretty_name, with_ret, fnname):
     for i in range(6):
         if (pretty_name, i) in ARRAY_ARGS:
             fn += f"\n\t\t\t(&arrinfo{i})"
+        elif (pretty_name, i) in BYTE_SPAN_ARGS:
+            fn += f"\n\t\t\t(&binfo{i})"
         elif (pretty_name, i) not in TYPE_ARR:
             fn += f"\n\t\t\t(arg{i})"
         else:

--- a/junction/syscall/systbl.py
+++ b/junction/syscall/systbl.py
@@ -141,6 +141,7 @@ ARRAY_ARGS = {
     ("epoll_wait", 1) : 2,
     ("epoll_pwait", 1) : 2,
     ("epoll_pwait2", 1) : 2,
+    ("recvmmsg", 1) : 2,
 }
 
 systabl_targets = [None for i in range(SYS_NR)]

--- a/junction/syscall/systbl.py
+++ b/junction/syscall/systbl.py
@@ -124,6 +124,8 @@ TYPE_ARR.update({
     ("waitid", 3): 'static_cast<strace::WaitOptions>',
     ("statx", 3): 'static_cast<strace::StatxMask>',
     ("statx", 2): 'static_cast<strace::AtFlag>',
+    ("getsockopt", 1): 'static_cast<strace::SockoptLevel>',
+    ("setsockopt", 1): 'static_cast<strace::SockoptLevel>',
 })
 
 SKIP_STRACE_TARGET = [

--- a/junction/syscall/systbl.py
+++ b/junction/syscall/systbl.py
@@ -56,6 +56,7 @@ STRACE_ARGS_THAT_ARE_PATHNAMES = set([
     ("symlink", 1),
     ("symlinkat", 0),
     ("symlinkat", 2),
+    ("statx", 1),
 ])
 
 AT_FDS = [
@@ -74,6 +75,7 @@ AT_FDS = [
     ("linkat", 0),
     ("linkat", 2),
     ("readlinkat", 0),
+    ("statx", 0),
 ]
 
 TYPE_ARR = {
@@ -120,6 +122,8 @@ TYPE_ARR.update({
     ("rt_sigprocmask", 0): 'static_cast<strace::SigProcMaskOp>',
     ("waitpid", 2): 'static_cast<strace::WaitOptions>',
     ("waitid", 3): 'static_cast<strace::WaitOptions>',
+    ("statx", 3): 'static_cast<strace::StatxMask>',
+    ("statx", 2): 'static_cast<strace::AtFlag>',
 })
 
 SKIP_STRACE_TARGET = [

--- a/junction/syscall/usys.txt
+++ b/junction/syscall/usys.txt
@@ -55,6 +55,7 @@ fstatfs
 stat
 lstat
 fstat
+statx
 getdents
 getdents64
 mkdir

--- a/junction/syscall/usys.txt
+++ b/junction/syscall/usys.txt
@@ -186,7 +186,7 @@ prctl
 times
 msync:::stub
 sched_setaffinity:::stub
-set_robust_list:::enosys_quiet
+set_robust_list:::stub
 rseq
 flock:::stub
 inotify_init
@@ -199,3 +199,4 @@ mlock2:::stub
 munlock:::stub
 mlockall:::stub
 munlockall:::stub
+setpriority:::stub

--- a/junction/syscall/usys.txt
+++ b/junction/syscall/usys.txt
@@ -87,6 +87,7 @@ setsockopt
 getsockopt
 recvfrom
 recvmsg
+recvmmsg
 sendto
 sendmsg
 sendmmsg
@@ -201,3 +202,4 @@ munlock:::stub
 mlockall:::stub
 munlockall:::stub
 setpriority:::stub
+getpriority:::stub

--- a/lib/patches/caladan/0007-add-space-for-Thread-class-in-struct-thread.patch
+++ b/lib/patches/caladan/0007-add-space-for-Thread-class-in-struct-thread.patch
@@ -1,4 +1,4 @@
-From 3d4b923679dae2c6830f44df91e6d380f94d98a7 Mon Sep 17 00:00:00 2001
+From d57babb0d52836090578e03bcb62a1ec2bc76507 Mon Sep 17 00:00:00 2001
 From: Josh Fried <joshuafried@gmail.com>
 Date: Sun, 19 Feb 2023 00:34:47 -0500
 Subject: [PATCH 07/13] add space for Thread class in struct thread
@@ -8,11 +8,11 @@ Subject: [PATCH 07/13] add space for Thread class in struct thread
  1 file changed, 1 insertion(+)
 
 diff --git a/inc/runtime/thread.h b/inc/runtime/thread.h
-index 5a68ebe..060b30d 100644
+index 3c80761..01c603a 100644
 --- a/inc/runtime/thread.h
 +++ b/inc/runtime/thread.h
-@@ -35,6 +35,7 @@ struct thread {
- 	struct list_node	interruptible_link;
+@@ -36,6 +36,7 @@ struct thread {
+ 	size_t			waitq_micros;
  	uint64_t	tlsvar;
  	uint64_t	fsbase;
 +	unsigned long		junction_tstate_buf[8];

--- a/lib/patches/caladan/0009-preemption-and-signal-updates.patch
+++ b/lib/patches/caladan/0009-preemption-and-signal-updates.patch
@@ -1,4 +1,4 @@
-From cb0cee6c7bf4e72708e8bf40c8898f92a061a114 Mon Sep 17 00:00:00 2001
+From 08e546ccaba95a3f6ce5f5e7982646e57ad00975 Mon Sep 17 00:00:00 2001
 From: Josh Fried <joshuafried@gmail.com>
 Date: Mon, 10 Jul 2023 03:17:58 -0400
 Subject: [PATCH 09/13] preemption and signal updates
@@ -11,11 +11,11 @@ Subject: [PATCH 09/13] preemption and signal updates
  4 files changed, 32 insertions(+), 3 deletions(-)
 
 diff --git a/inc/runtime/thread.h b/inc/runtime/thread.h
-index 9bb8882..3a61fdf 100644
+index 6b4ece2..4e3454e 100644
 --- a/inc/runtime/thread.h
 +++ b/inc/runtime/thread.h
-@@ -35,7 +35,7 @@ struct thread {
- 	struct list_node	interruptible_link;
+@@ -36,7 +36,7 @@ struct thread {
+ 	size_t			waitq_micros;
  	uint64_t	tlsvar;
  	uint64_t	fsbase;
 -	unsigned long		junction_tstate_buf[8];
@@ -24,7 +24,7 @@ index 9bb8882..3a61fdf 100644
  
  extern uint64_t thread_get_total_cycles(thread_t *th);
 diff --git a/runtime/defs.h b/runtime/defs.h
-index 694c199..3093af3 100644
+index 2725f37..726c10f 100644
 --- a/runtime/defs.h
 +++ b/runtime/defs.h
 @@ -71,6 +71,7 @@ struct stack {
@@ -48,7 +48,7 @@ index ad64206..de0fd8b 100644
  
  	if (sigemptyset(&act.sa_mask) != 0) {
 diff --git a/runtime/sched.c b/runtime/sched.c
-index b9d82be..f38396d 100644
+index 1a97084..ed817f3 100644
 --- a/runtime/sched.c
 +++ b/runtime/sched.c
 @@ -3,6 +3,7 @@
@@ -96,7 +96,7 @@ index b9d82be..f38396d 100644
  {
  	struct kthread *k = myk();
  	thread_t *myth = thread_self();
-@@ -997,6 +1017,7 @@ static void runtime_top_of_stack(void)
+@@ -998,6 +1018,7 @@ static void runtime_top_of_stack(void)
   */
  int sched_init_thread(void)
  {
@@ -104,7 +104,7 @@ index b9d82be..f38396d 100644
  	struct stack *s;
  
  	tcache_init_perthread(thread_tcache, perthread_ptr(thread_pt));
-@@ -1008,6 +1029,12 @@ int sched_init_thread(void)
+@@ -1009,6 +1030,12 @@ int sched_init_thread(void)
  	perthread_store(runtime_stack, (void *)stack_init_to_rsp(s, runtime_top_of_stack));
  	perthread_store(runtime_fsbase, _readfsbase_u64());
  

--- a/lib/patches/caladan/0011-add-support-for-interruptible-waiting.patch
+++ b/lib/patches/caladan/0011-add-support-for-interruptible-waiting.patch
@@ -1,4 +1,4 @@
-From 7fb46e16361b998744ebd19160aa0bca77f3c227 Mon Sep 17 00:00:00 2001
+From 0799a7ce15fa7b7147667764852216877e6d158c Mon Sep 17 00:00:00 2001
 From: Josh Fried <joshuafried@gmail.com>
 Date: Thu, 28 Sep 2023 22:57:58 +0000
 Subject: [PATCH 11/13] add support for interruptible waiting
@@ -9,7 +9,7 @@ Subject: [PATCH 11/13] add support for interruptible waiting
  2 files changed, 18 insertions(+), 11 deletions(-)
 
 diff --git a/inc/runtime/thread.h b/inc/runtime/thread.h
-index 3a61fdf..0b422c8 100644
+index 4e3454e..f3e3d18 100644
 --- a/inc/runtime/thread.h
 +++ b/inc/runtime/thread.h
 @@ -23,8 +23,13 @@ struct thread {
@@ -26,15 +26,15 @@ index 3a61fdf..0b422c8 100644
  	struct stack	*stack;
  	uint16_t	last_cpu;
  	uint16_t	cur_kthread;
-@@ -35,7 +40,6 @@ struct thread {
- 	struct list_node	interruptible_link;
+@@ -36,7 +41,6 @@ struct thread {
+ 	size_t			waitq_micros;
  	uint64_t	tlsvar;
  	uint64_t	fsbase;
 -	unsigned long		junction_tstate_buf[24];
  };
  
  extern uint64_t thread_get_total_cycles(thread_t *th);
-@@ -71,16 +75,6 @@ static inline thread_t *thread_self(void)
+@@ -72,16 +76,6 @@ static inline thread_t *thread_self(void)
  	return perthread_read_const_p(__const_self);
  }
  
@@ -52,7 +52,7 @@ index 3a61fdf..0b422c8 100644
  /*
   * High-level routines, use this API most of the time.
 diff --git a/runtime/sched.c b/runtime/sched.c
-index f38396d..3e86d37 100644
+index ed817f3..9c44e77 100644
 --- a/runtime/sched.c
 +++ b/runtime/sched.c
 @@ -41,6 +41,9 @@ static DEFINE_PERTHREAD(struct tcache_perthread, thread_pt);
@@ -87,9 +87,9 @@ index f38396d..3e86d37 100644
  	__jmp_thread_direct(&oldth->tf, &newth->tf, &oldth->thread_running);
  }
  
-@@ -843,6 +854,8 @@ static __always_inline thread_t *__thread_create(void)
- 	th->thread_ready = false;
+@@ -844,6 +855,8 @@ static __always_inline thread_t *__thread_create(void)
  	th->thread_running = false;
+ 	th->waitq_micros = 0;
  	th->tlsvar = 0;
 +	th->junction_thread = false;
 +	th->link_armed = false;

--- a/lib/patches/caladan/0013-thread-buffer-tweaks.patch
+++ b/lib/patches/caladan/0013-thread-buffer-tweaks.patch
@@ -1,4 +1,4 @@
-From a6fcfdfbf770302975931d388edb82eff157a96e Mon Sep 17 00:00:00 2001
+From eb04f13ca52e9834910888791ac32d06b06c7096 Mon Sep 17 00:00:00 2001
 From: Josh Fried <joshuafried@gmail.com>
 Date: Thu, 20 Jun 2024 19:27:11 -0400
 Subject: [PATCH 13/13] thread buffer tweaks
@@ -8,7 +8,7 @@ Subject: [PATCH 13/13] thread buffer tweaks
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/inc/runtime/thread.h b/inc/runtime/thread.h
-index e560d1a..57c622c 100644
+index 40efaf6..0e4a664 100644
 --- a/inc/runtime/thread.h
 +++ b/inc/runtime/thread.h
 @@ -31,7 +31,7 @@ struct thread {
@@ -20,8 +20,8 @@ index e560d1a..57c622c 100644
  	struct stack	*stack;
  	uint16_t	last_cpu;
  	uint16_t	cur_kthread;
-@@ -42,6 +42,7 @@ struct thread {
- 	struct list_node	interruptible_link;
+@@ -43,6 +43,7 @@ struct thread {
+ 	size_t			waitq_micros;
  	uint64_t	tlsvar;
  	uint64_t	fsbase;
 +	unsigned long	junction_cold_state_buf[32];

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -42,17 +42,6 @@ CMAKE=${BIN_DIR}/bin/cmake
 if [ "${CI}" = "ON" ];
 then
     . "${SCRIPT_DIR}"/submodule_check.sh --ci
-
-    echo "CI Mode: Patching Junction's Caladan API calls..."
-    TARGET_FILE_NET="${ROOT_DIR}/junction/bindings/net.h"
-    sed -i -E '/udp_readv_from2/,/peek, nonblocking\);/ s/peek, nonblocking\);/peek, nonblocking, nullptr\);/' "$TARGET_FILE_NET"
-    sed -i -E '/udp_writev_to2/,/raddr, nonblocking\);/ s/raddr, nonblocking\);/raddr, nonblocking, nullptr\);/' "$TARGET_FILE_NET"
-
-    TARGET_FILE_POD="${ROOT_DIR}/junction/snapshot/pod.h"
-    sed -i 's/archive(n.ip, n.port);/uint32_t ip = n.ip; uint16_t port = n.port; archive(ip, port); n.ip = ip; n.port = port;/' "$TARGET_FILE_POD"
-
-    cat "$TARGET_FILE_NET" 
-    cat "$TARGET_FILE_POD"
 else
     . "${SCRIPT_DIR}"/submodule_check.sh
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,6 +39,14 @@ CMAKE=${BIN_DIR}/bin/cmake
 
 . "${SCRIPT_DIR}"/submodule_check.sh
 
+if [ "$SNAP_SAMPLES" = "ON" ] && [ ! -f "${ROOT_DIR}/.function_bench_installed" ]; then
+    set +x
+	echo -n -e "$RED"
+    echo "Snapshot samples require Function Bench to be installed. Please run scripts/install_function_bench.sh first."
+    echo -e "$NC"
+    exit 1
+fi
+
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,4 +25,7 @@ cd $SCRIPT_DIR
 ./install_caladan.sh
 ./install_glibc.sh
 ./install_flatbuffers.sh
-./install_function_bench.sh
+
+touch ${ROOT_DIR}/.install_script_ran
+
+#./install_function_bench.sh

--- a/scripts/install_caladan.sh
+++ b/scripts/install_caladan.sh
@@ -18,7 +18,7 @@ cd $CALADAN_DIR/
 git -c user.name="x" -c user.email="x" am $CALADAN_PATCHES_DIR/*
 
 prev=$(cat "$ROOT_DIR/lib/.caladan_installed_ver" 2>&1 || true)
-cur=$(cat "$CALADAN_PATCHES_DIR"/* | sha256sum)
+cur=$((cd ${ROOT_DIR}; git ls-tree HEAD lib/caladan; cat "$CALADAN_PATCHES_DIR"/*) | sha256sum)
 
 # Install Caladan
 if [ "$prev" != "$cur" ] || [ ! -f $CALADAN_DIR/deps/pcm/build/src/libpcm.a ]; then
@@ -27,4 +27,4 @@ fi
 
 (cd ksched && make -j `nproc`)
 
-cat $CALADAN_PATCHES_DIR/* | sha256sum >  $CALADAN_DIR/../.caladan_installed_ver
+printf '%s\n' "$cur" > $CALADAN_DIR/../.caladan_installed_ver

--- a/scripts/install_function_bench.sh
+++ b/scripts/install_function_bench.sh
@@ -10,7 +10,7 @@ VENV_DIR=${ROOT_DIR}/bin/venv
 sudo -E apt install -y libgl1 python3-venv python3-grpcio python3-grpc-tools
 mkdir -p ${ROOT_DIR}/bin/
 python3 -m venv ${VENV_DIR}
-${VENV_DIR}/bin/pip install chameleon pillow numpy pyaes six torch opencv-python scikit-learn pandas tensorflow grpcio grpcio-tools minio #[and-cuda]
+${VENV_DIR}/bin/pip install chameleon pillow numpy pyaes six torch opencv-python scikit-learn pandas tensorflow-cpu grpcio grpcio-tools minio --extra-index-url https://download.pytorch.org/whl/cpu #[and-cuda]
 
 pushd ${ROOT_DIR}/bin/
 npm install sharp

--- a/scripts/install_function_bench.sh
+++ b/scripts/install_function_bench.sh
@@ -22,3 +22,5 @@ if [ ! -f "minio" ]; then
   mv minio.download minio
 fi
 popd
+
+touch ${ROOT_DIR}/.function_bench_installed

--- a/scripts/install_glibc.sh
+++ b/scripts/install_glibc.sh
@@ -12,7 +12,7 @@ GLIBC_INSTALL_DIR=${ROOT_DIR}/install
 mkdir -p $GLIBC_INSTALL_DIR
 
 prev=$(cat "$ROOT_DIR/lib/.glibc_installed_ver" 2>&1 || true)
-cur=$(cat "$GLIBC_PATCHES_DIR"/* | sha256sum)
+cur=$((cd $ROOT_DIR; git ls-tree HEAD lib/glibc; cat "$GLIBC_PATCHES_DIR"/*) | sha256sum)
 
 if [ "$prev" == "$cur" ] && [ -f $GLIBC_INSTALL_DIR/lib/ld-linux-x86-64.so.2 ] && [ -f $GLIBC_INSTALL_DIR/lib/libc.so.6 ]; then
   exit 0
@@ -45,4 +45,4 @@ make -j "$(nproc)" CFLAGS="-U_FORTIFY_SOURCE -O3"
 make install -j "$(nproc)"
 
 # record the set of patches used for this build
-cat $GLIBC_PATCHES_DIR/* | sha256sum >  $GLIBC_DIR/../.glibc_installed_ver
+printf '%s\n' "$cur" >  $GLIBC_DIR/../.glibc_installed_ver

--- a/scripts/submodule_check.sh
+++ b/scripts/submodule_check.sh
@@ -8,8 +8,15 @@ GLIBC_PATCHES_DIR=${ROOT_DIR}/lib/patches/glibc
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
+if [ ! -f ${ROOT_DIR}/.install_script_ran ]; then
+	echo -n -e "$RED"
+	echo "Please run scripts/install.sh first."
+	echo -e "$NC"
+	exit 1
+fi
+
 prev=$(cat "$ROOT_DIR/lib/.caladan_installed_ver" 2>&1 || true)
-cur=$(cat "$CALADAN_PATCHES_DIR"/* | sha256sum)
+cur=$((cd ${ROOT_DIR}; git ls-tree HEAD lib/caladan; cat "$CALADAN_PATCHES_DIR"/*) | sha256sum)
 
 err=0
 
@@ -19,10 +26,12 @@ if [ "$prev" != "$cur" ]; then
 	echo "Please run scripts/install_caladan.sh to update"
 	echo -e "$NC"
 	err=1
+	echo prev $prev
+	echo cur $cur
 fi
 
 prev=$(cat "$ROOT_DIR/lib/.glibc_installed_ver" 2>&1 || true)
-cur=$(cat "$GLIBC_PATCHES_DIR"/* | sha256sum)
+cur=$((git ls-tree HEAD ${ROOT_DIR}/lib/glibc; cat "$GLIBC_PATCHES_DIR"/*) | sha256sum)
 
 if [ "$prev" != "$cur" ]; then
 	echo -n -e "$RED"

--- a/scripts/tools/gdb_find_symbols.py
+++ b/scripts/tools/gdb_find_symbols.py
@@ -185,7 +185,10 @@ if not pid:
         print(e)
         exit(-1)
 
-for filename, real_start in get_offsets(offsets_from_junction_map()):
+try:
+  for filename, real_start in get_offsets(offsets_from_junction_map()):
     outf(f"add-symbol-file {filename} -o {hex(real_start)}")
-#for filename, real_start in get_offsets(offsets_from_linux_map(pid)):
-#    outf(f"add-symbol-file {filename} -o {hex(real_start)}")
+except:
+  print("Using fallback method")
+  for filename, real_start in get_offsets(offsets_from_linux_map(pid)):
+    outf(f"add-symbol-file {filename} -o {hex(real_start)}")


### PR DESCRIPTION
# Changes Summary (Generated by Copilot)

This PR merges upstream commits from upstream (junction/dev) to dev branch.

## **Changes to Accommodate Merge**
- Formatting of upstream's changes
- Reverted manual patches to Junction's Caladan API calls in `junction/scripts/build.sh`

## **Core functionality improvements and refactoring**

1. **Networking Stack Enhancements:**
   - Added `BindToken` class for managing port reservations before creating sockets
   - Improved socket options handling (IP_RECVTOS, IP_PKTINFO, SO_RCVTIMEO, SO_SNDTIMEO)
   - Added support for socket timeouts via `RuntimeWaitqTimeout`
   - Enhanced UDP/TCP socket implementations with better state management
   - Added auxiliary packet data support (`aux_rx_pkt_data`, `aux_tx_pkt_data`) for receiving TOS/ECN fields

2. **File System Improvements:**
   - Added `O_PATH` file type support
   - Implemented `O_TMPFILE` for creating temporary files
   - Fixed root directory handling for ". ." navigation
   - Improved path resolution and symlink handling
   - Added empty path handling for `AT_EMPTY_PATH` flag

3. **Process & Thread Management:**
   - Enhanced process creation with customizable filesystem root and working directory
   - Added `PS` command to control plane for listing processes
   - Improved thread signal handling and exit flow
   - Better integration between control connections and process stdio

4. **Memory Management:**
   - Fixed syscall stack bottom calculation (accounting for red zone)
   - Improved memory mapping and file-backed memory handling

## **New features and enhancements**

1. **Control Plane Features:**
   - `run_aux` command now captures stdout/stderr to control connection
   - New `ps` command for listing all processes
   - Enhanced `run` response to include PID
   - Added filesystem root and working directory parameters

2. **Network Features:**
   - `recvmmsg` syscall implementation
   - Control message (cmsg) support for IP_TOS in sendmsg/recvmsg
   - Socket option getting/setting infrastructure
   - Bind token system for port reservation

3. **File System Features:**
   - `statx` syscall support
   - Temporary file creation (`O_TMPFILE`)
   - Path-only file descriptors (`O_PATH`)
   - Better linuxfs mounting (can now mount individual files, not just directories)

## **Bug fixes and optimizations**

1. **Fixes:**
   - Fixed eventfd write notification (force notify on write)
   - Fixed file table resize bug
   - Fixed advisory lock map static initialization
   - Fixed rseq header inclusion
   - Fixed memfs initialization fallback for older kernels
   - Corrected TCP/UDP socket state transitions
   - Fixed fcntl F_SETFL/F_GETFL flag handling
   - Fixed linuxfs rename to update internal paths

2. **Optimizations:**
   - Moved strace maps to separate compilation unit (reduces compile time)
   - Improved strace output with better formatting
   - Reduced memfs max file size from 1GB to 256MB (but increased max files)
   - Better RCU usage for file operations

## **Documentation updates**

1. **Code Comments:**
   - Added explanations for syscall stack red zone
   - Documented bind token usage
   - Improved inline documentation for socket options

## **Configuration changes**

1. **Build System:**
   - Added Python flatbuffers generation for control schema
   - Improved submodule checking with git ls-tree
   - Added function bench installation detection
   - Better CI mode handling

2. **Runtime Configuration:**
   - Removed direct references to snapshot prefix configuration
   - Better error messages on initialization failures

## **Dependency updates**

1. **Caladan Submodule:**
   - Updated from `ca976910` to `5dccc715`
   - Includes waitq_micros support for blocking timeouts
   - Thread state buffer adjustments

2. **Patches:**
   - Updated Caladan patches for new thread buffer layout
   - Thread structure now includes `waitq_micros` field for timeout support