### PR TITLE
feat: add sidecar

### DIFF
--- a/junction/samples/serverless/http/CMakeLists.txt
+++ b/junction/samples/serverless/http/CMakeLists.txt
@@ -55,3 +55,8 @@ add_executable(follower_service
     watchdog.cc
     gateway_client.cc
 )
+
+add_executable(proxy_service
+    proxy_service.cc
+    lib/httplib.h
+)

--- a/junction/samples/serverless/http/controller.cc
+++ b/junction/samples/serverless/http/controller.cc
@@ -9,6 +9,7 @@ extern char **environ;
 const std::string CURR_DIR = "./samples/serverless/http/";
 const std::string USER_BIN = "user_service";
 const std::string FOLLOWER_BIN = "follower_service";
+const std::string PROXY_BIN = "proxy_service";
 
 constexpr int CONTROLLER_PORT = 8080;
 
@@ -45,8 +46,8 @@ httplib::Server::Handler SocketHandler(const std::string &sock_path) {
       res.status = func_res->status;
       res.body = func_res->body;
       for (const auto &header : func_res->headers) {
-        if (header.first != "Content-Length" &&
-            header.first != "Transfer-Encoding") {
+        if (header.first != "content-length" &&
+            header.first != "transfer-encoding") {
           res.set_header(header.first, header.second);
         }
       }
@@ -78,6 +79,7 @@ int main(int argc, char *argv[]) {
   }
   if (!SpawnService(CURR_DIR + USER_BIN, false)) { exit(1); }
   if (!SpawnService(CURR_DIR + FOLLOWER_BIN, enable_interception)) { exit(1); }
+  if (!SpawnService(CURR_DIR + PROXY_BIN, false)) { exit(1); }
 
   if (!InitServer()) {
     std::cerr << "[Controller] Failed to listen on port: " << CONTROLLER_PORT

--- a/junction/samples/serverless/http/proxy_service.cc
+++ b/junction/samples/serverless/http/proxy_service.cc
@@ -1,0 +1,49 @@
+#include <iostream>
+
+#include "lib/httplib.h"
+
+namespace {
+
+constexpr int PROXY_PORT = 9000;
+const std::string USER_SOCK = "/tmp/serverless/user.sock";
+
+void ProxyHandler(const httplib::Request &req, httplib::Response &res) {
+  if (req.method != "GET" || req.path.find("/user/") == std::string::npos) {
+    res.status = httplib::StatusCode::MethodNotAllowed_405;
+    res.set_content("Method not allowed", "text/plain");
+    return;
+  }
+  httplib::Client cli(USER_SOCK);
+  cli.set_address_family(AF_UNIX);
+  auto func_res = cli.Get(req.path, req.headers);
+  if (func_res) {
+    res.status = func_res->status;
+    res.body = func_res->body;
+    for (const auto &header : func_res->headers) {
+      if (header.first != "content-length" &&
+          header.first != "transfer-encoding") {
+        res.set_header(header.first, header.second);
+      }
+    }
+  } else {
+    res.status = httplib::StatusCode::BadGateway_502;
+    res.set_content("Bad Gateway: Function Unreachable", "text/plain");
+  }
+}
+}  // namespace
+
+int main() {
+  httplib::Server svr;
+  svr.Get(".*", ProxyHandler);
+  svr.Post(".*", ProxyHandler);
+  svr.Put(".*", ProxyHandler);
+  svr.Delete(".*", ProxyHandler);
+
+  std::cout << "[Proxy Service] Listening on 0.0.0.0:" << PROXY_PORT
+            << std::endl;
+  if (!svr.listen("0.0.0.0", PROXY_PORT)) {
+    std::cerr << "[Proxy Service] Server failed to listen" << std::endl;
+    exit(1);
+  }
+  return 0;
+}


### PR DESCRIPTION
Added a `proxy_service` which listens on port 9000 to handle socket communication between functions in the same address space. 

Closes #41 