### PR TITLE
feat: add LD_PRELOAD shim

### DIFF
--- a/junction/samples/serverless/http/CMakeLists.txt
+++ b/junction/samples/serverless/http/CMakeLists.txt
@@ -60,3 +60,6 @@ add_executable(proxy_service
     proxy_service.cc
     lib/httplib.h
 )
+
+# shim
+add_library(shim SHARED shim.cc)

--- a/junction/samples/serverless/http/controller.cc
+++ b/junction/samples/serverless/http/controller.cc
@@ -17,10 +17,17 @@ const std::string SOCK_PATH = "/tmp/serverless/";
 const std::string USER_SOCK = "user.sock";
 const std::string FOLLOWER_SOCK = "follower.sock";
 
+const std::string SHIM_SO = "libshim.so";
+
 namespace {
 
-bool SpawnService(const std::string &bin, bool enable_interception) {
+bool SpawnService(const std::string &bin, bool enable_interception,
+                  bool enable_shim) {
   std::vector<char *> args;
+  if (enable_shim) {
+    args.push_back(
+        const_cast<char *>(("LD_PRELOAD=" + CURR_DIR + SHIM_SO).c_str()));
+  }
   args.push_back(const_cast<char *>(bin.c_str()));
   if (enable_interception) { args.push_back(const_cast<char *>("--int")); }
   args.push_back(nullptr);
@@ -77,9 +84,11 @@ int main(int argc, char *argv[]) {
     enable_interception = true;
     std::cout << "[Controller] Interception enabled." << std::endl;
   }
-  if (!SpawnService(CURR_DIR + USER_BIN, false)) { exit(1); }
-  if (!SpawnService(CURR_DIR + FOLLOWER_BIN, enable_interception)) { exit(1); }
-  if (!SpawnService(CURR_DIR + PROXY_BIN, false)) { exit(1); }
+  if (!SpawnService(CURR_DIR + USER_BIN, false, true)) { exit(1); }
+  if (!SpawnService(CURR_DIR + FOLLOWER_BIN, enable_interception, true)) {
+    exit(1);
+  }
+  if (!SpawnService(CURR_DIR + PROXY_BIN, false, false)) { exit(1); }
 
   if (!InitServer()) {
     std::cerr << "[Controller] Failed to listen on port: " << CONTROLLER_PORT

--- a/junction/samples/serverless/http/controller.cc
+++ b/junction/samples/serverless/http/controller.cc
@@ -21,19 +21,17 @@ const std::string SHIM_SO = "libshim.so";
 
 namespace {
 
-bool SpawnService(const std::string &bin, bool enable_interception,
-                  bool enable_shim) {
+bool SpawnService(const std::string &bin, bool enable_interception) {
   // create args
   std::vector<char *> args;
   args.push_back(const_cast<char *>(bin.c_str()));
-  if (enable_interception) { args.push_back(const_cast<char *>("--int")); }
   args.push_back(nullptr);
 
   // create envs
   std::vector<char *> envs;
-  for (char **env = environ; *env != 0; env++) { envs.push_back(*env); }
+  for (char **env = environ; *env != nullptr; env++) { envs.push_back(*env); }
   std::string preload_str;
-  if (enable_shim) {
+  if (enable_interception) {
     preload_str = "LD_PRELOAD=" + CURR_DIR + SHIM_SO;
     envs.push_back(const_cast<char *>(preload_str.c_str()));
   }
@@ -42,7 +40,7 @@ bool SpawnService(const std::string &bin, bool enable_interception,
   // log command
   std::stringstream log_ss;
   log_ss << "[Controller] Spawning: ";
-  if (enable_shim) { log_ss << preload_str << " "; }
+  if (enable_interception) { log_ss << preload_str << " "; }
   for (auto *arg : args) {
     if (arg != nullptr) { log_ss << arg << " "; }
   }
@@ -101,11 +99,9 @@ int main(int argc, char *argv[]) {
     enable_interception = true;
     std::cout << "[Controller] Interception enabled." << std::endl;
   }
-  if (!SpawnService(CURR_DIR + USER_BIN, false, true)) { exit(1); }
-  if (!SpawnService(CURR_DIR + FOLLOWER_BIN, enable_interception, true)) {
-    exit(1);
-  }
-  if (!SpawnService(CURR_DIR + PROXY_BIN, false, false)) { exit(1); }
+  if (!SpawnService(CURR_DIR + USER_BIN, enable_interception)) { exit(1); }
+  if (!SpawnService(CURR_DIR + FOLLOWER_BIN, enable_interception)) { exit(1); }
+  if (!SpawnService(CURR_DIR + PROXY_BIN, false)) { exit(1); }
 
   if (!InitServer()) {
     std::cerr << "[Controller] Failed to listen on port: " << CONTROLLER_PORT

--- a/junction/samples/serverless/http/controller.cc
+++ b/junction/samples/serverless/http/controller.cc
@@ -23,18 +23,35 @@ namespace {
 
 bool SpawnService(const std::string &bin, bool enable_interception,
                   bool enable_shim) {
+  // create args
   std::vector<char *> args;
-  if (enable_shim) {
-    args.push_back(
-        const_cast<char *>(("LD_PRELOAD=" + CURR_DIR + SHIM_SO).c_str()));
-  }
   args.push_back(const_cast<char *>(bin.c_str()));
   if (enable_interception) { args.push_back(const_cast<char *>("--int")); }
   args.push_back(nullptr);
 
+  // create envs
+  std::vector<char *> envs;
+  for (char **env = environ; *env != 0; env++) { envs.push_back(*env); }
+  std::string preload_str;
+  if (enable_shim) {
+    preload_str = "LD_PRELOAD=" + CURR_DIR + SHIM_SO;
+    envs.push_back(const_cast<char *>(preload_str.c_str()));
+  }
+  envs.push_back(nullptr);
+
+  // log command
+  std::stringstream log_ss;
+  log_ss << "[Controller] Spawning: ";
+  if (enable_shim) { log_ss << preload_str << " "; }
+  for (auto *arg : args) {
+    if (arg != nullptr) { log_ss << arg << " "; }
+  }
+  std::cout << log_ss.str() << std::endl;
+
+  // spawn
   pid_t pid;
-  if (posix_spawn(&pid, bin.c_str(), nullptr, nullptr, args.data(), environ) ==
-      0) {
+  if (posix_spawn(&pid, bin.c_str(), nullptr, nullptr, args.data(),
+                  envs.data()) == 0) {
     std::cout << "[Controller] Service spawned successfuly. PID: " << pid
               << std::endl;
     return true;

--- a/junction/samples/serverless/http/follower_service.cc
+++ b/junction/samples/serverless/http/follower_service.cc
@@ -8,7 +8,6 @@
 #include "watchdog.h"
 
 namespace {
-bool enable_interception = false;
 
 std::unordered_map<int, std::vector<int>> GenerateFollowers(int count) {
   std::unordered_map<int, std::vector<int>> db;
@@ -31,8 +30,7 @@ void GetFollowersHandler(const httplib::Request &req, httplib::Response &res) {
     std::string req_path = "/user/";
     std::vector<std::string> names;
     for (const int &id : followers) {
-      names.push_back(
-          CallGateway(req_path + std::to_string(id), enable_interception));
+      names.push_back(CallGateway(req_path + std::to_string(id)));
     }
     res.set_content(boost::algorithm::join(names, ", "), "text/plain");
   } catch (...) {
@@ -42,10 +40,7 @@ void GetFollowersHandler(const httplib::Request &req, httplib::Response &res) {
 }
 }  // namespace
 
-int main(int argc, char *argv[]) {
-  if (argc > 1 && std::strcmp(argv[1], "--int") == 0) {
-    enable_interception = true;
-  }
+int main() {
   WatchDog w("follower", "/followers/:id", GetFollowersHandler);
   w.Run();
   return 0;

--- a/junction/samples/serverless/http/gateway_client.cc
+++ b/junction/samples/serverless/http/gateway_client.cc
@@ -1,7 +1,5 @@
 #include "gateway_client.h"
 
-#include <iostream>
-
 #include "lib/httplib.h"
 
 constexpr int GATEWAY_PORT = 8080;
@@ -15,14 +13,7 @@ const std::string USER_SOCK = "/tmp/serverless/user.sock";
  * @param req
  * @return response
  */
-std::string CallGateway(std::string_view req, bool enable_interception) {
-  if (enable_interception && req.find("/user/") != std::string::npos) {
-    std::cout << "[CallGateway] Intercepted request: " << req << std::endl;
-    httplib::Client sock_cli(USER_SOCK);
-    sock_cli.set_address_family(AF_UNIX);
-    auto sock_res = sock_cli.Get(std::string(req));
-    return sock_res->body;
-  }
+std::string CallGateway(std::string_view req) {
   httplib::Client cli(GATEWAY_IP, GATEWAY_PORT);
   auto res = cli.Get(std::string(req));
   return res->body;

--- a/junction/samples/serverless/http/gateway_client.h
+++ b/junction/samples/serverless/http/gateway_client.h
@@ -2,4 +2,4 @@
 
 #include <string>
 
-std::string CallGateway(std::string_view req, bool enable_interception);
+std::string CallGateway(std::string_view req);

--- a/junction/samples/serverless/http/shim.cc
+++ b/junction/samples/serverless/http/shim.cc
@@ -1,0 +1,43 @@
+#include <arpa/inet.h>
+#include <dlfcn.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include <cstring>
+#include <iostream>
+
+constexpr const char *GATEWAY_IP = "10.10.1.1";
+constexpr int GATEWAY_PORT = 8080;
+constexpr int SIDECAR_PORT = 9000;
+
+using connect_func_t = int (*)(int, const struct sockaddr *, socklen_t);
+
+extern "C" int connect(int sockfd, const struct sockaddr *addr,
+                       socklen_t addrlen) {
+  // get real connect function
+  static connect_func_t real_connect = nullptr;
+  if (!real_connect) {
+    real_connect = (connect_func_t)dlsym(RTLD_NEXT, "connect");
+  }
+  if (addr->sa_family == AF_INET) {
+    const auto *addr_in = (const struct sockaddr_in *)addr;
+    char ip_str[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &(addr_in->sin_addr), ip_str, INET_ADDRSTRLEN);
+    int port = ntohs(addr_in->sin_port);
+
+    if (strcmp(ip_str, GATEWAY_IP) == 0 && port == GATEWAY_PORT) {
+      // intercept if it is trying to connect to the gateway
+      std::cout << "[Shim] Intercepting connection to gateway and redirecting "
+                   "to sidecar"
+                << std::endl;
+      struct sockaddr_in sidecar_addr;
+      memset(&sidecar_addr, 0, sizeof(sidecar_addr));
+      sidecar_addr.sin_family = AF_INET;
+      sidecar_addr.sin_port = htons(SIDECAR_PORT);
+      inet_pton(AF_INET, "0.0.0.0", &sidecar_addr.sin_addr);
+      return real_connect(sockfd, (struct sockaddr *)&sidecar_addr,
+                          sizeof(sidecar_addr));
+    }
+  }
+  return real_connect(sockfd, addr, addrlen);
+}

--- a/junction/samples/serverless/http/shim.cc
+++ b/junction/samples/serverless/http/shim.cc
@@ -3,11 +3,12 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 
+#include <cstdio>
 #include <cstring>
-#include <iostream>
 
 constexpr const char *GATEWAY_IP = "10.10.1.1";
 constexpr int GATEWAY_PORT = 8080;
+constexpr const char *SIDECAR_IP = "127.0.0.1";
 constexpr int SIDECAR_PORT = 9000;
 
 using connect_func_t = int (*)(int, const struct sockaddr *, socklen_t);
@@ -18,6 +19,11 @@ extern "C" int connect(int sockfd, const struct sockaddr *addr,
   static connect_func_t real_connect = nullptr;
   if (!real_connect) {
     real_connect = (connect_func_t)dlsym(RTLD_NEXT, "connect");
+    if (!real_connect) {
+      fprintf(stderr,
+              "[Shim] Critical Error: dlsym failed to find 'connect'\n");
+      return -1;
+    }
   }
   if (addr->sa_family == AF_INET) {
     const auto *addr_in = (const struct sockaddr_in *)addr;
@@ -27,14 +33,16 @@ extern "C" int connect(int sockfd, const struct sockaddr *addr,
 
     if (strcmp(ip_str, GATEWAY_IP) == 0 && port == GATEWAY_PORT) {
       // intercept if it is trying to connect to the gateway
-      std::cout << "[Shim] Intercepting connection to gateway and redirecting "
-                   "to sidecar"
-                << std::endl;
+      fprintf(stderr, "[Shim] Intercepting %s:%d -> Redirecting to %s:%d\n",
+              ip_str, port, SIDECAR_IP, SIDECAR_PORT);
       struct sockaddr_in sidecar_addr;
       memset(&sidecar_addr, 0, sizeof(sidecar_addr));
       sidecar_addr.sin_family = AF_INET;
       sidecar_addr.sin_port = htons(SIDECAR_PORT);
-      inet_pton(AF_INET, "0.0.0.0", &sidecar_addr.sin_addr);
+      if (inet_pton(AF_INET, SIDECAR_IP, &sidecar_addr.sin_addr) <= 0) {
+        fprintf(stderr, "[Shim] Error: Failed to convert Sidecar IP\n");
+        return -1;
+      }
       return real_connect(sockfd, (struct sockaddr *)&sidecar_addr,
                           sizeof(sidecar_addr));
     }


### PR DESCRIPTION
Added a shim that wraps the connect function call to use direct unix socket communication between functions.
In order to use this, the binary simply has to be run with the `LD_PRELOAD=libshim.so` env variable.
Removed the interception logic from the `CallGateway` function.

Closes #42 