### PR TITLE
enhance: patch getsockopt and setsockopt

### DIFF
--- a/junction/samples/serverless/http/CMakeLists.txt
+++ b/junction/samples/serverless/http/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(proxy_service
 file(COPY watchdog.py
     user_service.py
     follower_service.py
+    patch.py
     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 # shim

--- a/junction/samples/serverless/http/follower_service.py
+++ b/junction/samples/serverless/http/follower_service.py
@@ -2,9 +2,20 @@ import http.client
 from http.server import BaseHTTPRequestHandler
 import sys
 from watchdog import WatchDog
-import patch
 
-patch.patch_socket()
+import socket
+
+def patch_socket():
+    _original_setsockopt = socket.socket.setsockopt
+
+    def patched_setsockopt(self, level, optname, value):
+        try:
+            _original_setsockopt(self, level, optname, value)
+        except OSError:
+            # Ignore "Invalid argument" or "Protocol not available" from the runtime
+            pass
+
+    socket.socket.setsockopt = patched_setsockopt
 
 # --- 1. CONFIGURATION ---
 GATEWAY_IP = "10.10.1.1"

--- a/junction/samples/serverless/http/follower_service.py
+++ b/junction/samples/serverless/http/follower_service.py
@@ -2,21 +2,9 @@ import http.client
 from http.server import BaseHTTPRequestHandler
 import sys
 import socket
+import patch
 
-# --- 0. MONKEY PATCH FOR JUNCTION / LIBOS ---
-# Junction does not support setsockopt, which http.client tries to use (TCP_NODELAY).
-# We wrap the standard setsockopt to ignore errors.
-_original_setsockopt = socket.socket.setsockopt
-
-def patched_setsockopt(self, level, optname, value):
-    try:
-        _original_setsockopt(self, level, optname, value)
-    except OSError:
-        # Ignore "Invalid argument" or "Protocol not available" from the runtime
-        pass
-
-socket.socket.setsockopt = patched_setsockopt
-# --------------------------------------------
+patch.patch_socket()
 
 from watchdog import WatchDog
 

--- a/junction/samples/serverless/http/follower_service.py
+++ b/junction/samples/serverless/http/follower_service.py
@@ -2,20 +2,9 @@ import http.client
 from http.server import BaseHTTPRequestHandler
 import sys
 from watchdog import WatchDog
+import patch
 
-import socket
-
-def patch_socket():
-    _original_setsockopt = socket.socket.setsockopt
-
-    def patched_setsockopt(self, level, optname, value):
-        try:
-            _original_setsockopt(self, level, optname, value)
-        except OSError:
-            # Ignore "Invalid argument" or "Protocol not available" from the runtime
-            pass
-
-    socket.socket.setsockopt = patched_setsockopt
+patch.patch_socket()
 
 # --- 1. CONFIGURATION ---
 GATEWAY_IP = "10.10.1.1"

--- a/junction/samples/serverless/http/follower_service.py
+++ b/junction/samples/serverless/http/follower_service.py
@@ -2,11 +2,10 @@ import http.client
 from http.server import BaseHTTPRequestHandler
 import sys
 import socket
+from watchdog import WatchDog
 import patch
 
 patch.patch_socket()
-
-from watchdog import WatchDog
 
 # --- 1. CONFIGURATION ---
 GATEWAY_IP = "10.10.1.1"

--- a/junction/samples/serverless/http/follower_service.py
+++ b/junction/samples/serverless/http/follower_service.py
@@ -1,7 +1,6 @@
 import http.client
 from http.server import BaseHTTPRequestHandler
 import sys
-import socket
 from watchdog import WatchDog
 import patch
 

--- a/junction/samples/serverless/http/lib/httplib.h
+++ b/junction/samples/serverless/http/lib/httplib.h
@@ -309,6 +309,33 @@ using socket_t = int;
 #include <unordered_set>
 #include <utility>
 
+// =========================================================================
+// PATCH FOR JUNCTION / LIBOS (Disable unsupported socket options)
+// =========================================================================
+
+// 1. Patch setsockopt (Prevent "Unsupported" errors logs)
+inline int patched_setsockopt(int sockfd, int level, int optname, 
+                              const void *optval, socklen_t optlen) {
+    return 0; // Always pretend success
+}
+
+// 2. Patch getsockopt (Prevent connection retry loops)
+inline int patched_getsockopt(int sockfd, int level, int optname, 
+                              void *optval, socklen_t *optlen) {
+    // If checking for SO_ERROR, we must zero out the value to signal "No Error"
+    if (optval && optlen && *optlen > 0) {
+        size_t safe_len = *optlen;
+        if (safe_len > sizeof(int)) safe_len = sizeof(int);
+        std::memset(optval, 0, safe_len);
+    }
+    return 0; // Always pretend success
+}
+
+// 3. Apply the overrides
+#define setsockopt patched_setsockopt
+#define getsockopt patched_getsockopt
+// =========================================================================
+
 #if defined(CPPHTTPLIB_USE_NON_BLOCKING_GETADDRINFO) || \
     defined(CPPHTTPLIB_USE_CERTS_FROM_MACOSX_KEYCHAIN)
 #if TARGET_OS_MAC

--- a/junction/samples/serverless/http/lib/httplib.h
+++ b/junction/samples/serverless/http/lib/httplib.h
@@ -314,21 +314,21 @@ using socket_t = int;
 // =========================================================================
 
 // 1. Patch setsockopt (Prevent "Unsupported" errors logs)
-inline int patched_setsockopt(int sockfd, int level, int optname, 
+inline int patched_setsockopt(int sockfd, int level, int optname,
                               const void *optval, socklen_t optlen) {
-    return 0; // Always pretend success
+  return 0;  // Always pretend success
 }
 
 // 2. Patch getsockopt (Prevent connection retry loops)
-inline int patched_getsockopt(int sockfd, int level, int optname, 
-                              void *optval, socklen_t *optlen) {
-    // If checking for SO_ERROR, we must zero out the value to signal "No Error"
-    if (optval && optlen && *optlen > 0) {
-        size_t safe_len = *optlen;
-        if (safe_len > sizeof(int)) safe_len = sizeof(int);
-        std::memset(optval, 0, safe_len);
-    }
-    return 0; // Always pretend success
+inline int patched_getsockopt(int sockfd, int level, int optname, void *optval,
+                              socklen_t *optlen) {
+  // If checking for SO_ERROR, we must zero out the value to signal "No Error"
+  if (optval && optlen && *optlen > 0) {
+    size_t safe_len = *optlen;
+    if (safe_len > sizeof(int)) safe_len = sizeof(int);
+    std::memset(optval, 0, safe_len);
+  }
+  return 0;  // Always pretend success
 }
 
 // 3. Apply the overrides

--- a/junction/samples/serverless/http/patch.py
+++ b/junction/samples/serverless/http/patch.py
@@ -1,0 +1,13 @@
+import socket
+
+def patch_socket():
+    _original_setsockopt = socket.socket.setsockopt
+
+    def patched_setsockopt(self, level, optname, value):
+        try:
+            _original_setsockopt(self, level, optname, value)
+        except OSError:
+            # Ignore "Invalid argument" or "Protocol not available" from the runtime
+            pass
+
+    socket.socket.setsockopt = patched_setsockopt

--- a/junction/samples/serverless/http/patch.py
+++ b/junction/samples/serverless/http/patch.py
@@ -4,4 +4,4 @@ def patch_socket():
     def noop_setsockopt(self, level, optname, value):
         pass
 
-    socket.socket.setsockopt = patched_setsockopt
+    socket.socket.setsockopt = noop_setsockopt

--- a/junction/samples/serverless/http/patch.py
+++ b/junction/samples/serverless/http/patch.py
@@ -1,13 +1,7 @@
 import socket
 
 def patch_socket():
-    _original_setsockopt = socket.socket.setsockopt
-
-    def patched_setsockopt(self, level, optname, value):
-        try:
-            _original_setsockopt(self, level, optname, value)
-        except OSError:
-            # Ignore "Invalid argument" or "Protocol not available" from the runtime
-            pass
+    def noop_setsockopt(self, level, optname, value):
+        pass
 
     socket.socket.setsockopt = patched_setsockopt

--- a/junction/samples/serverless/http/user_service.py
+++ b/junction/samples/serverless/http/user_service.py
@@ -1,6 +1,9 @@
 from http.server import BaseHTTPRequestHandler
 import urllib.parse
 from watchdog import WatchDog
+import patch
+
+patch.patch_socket()
 
 # --- 1. Generate Database ---
 USERS_DB = {i: f"user_{i}" for i in range(100)}

--- a/junction/samples/serverless/http/watchdog.py
+++ b/junction/samples/serverless/http/watchdog.py
@@ -2,6 +2,9 @@ import os
 import socket
 import sys
 from http.server import HTTPServer, BaseHTTPRequestHandler
+import patch
+
+patch.patch_socket()
 
 SOCK_DIR = "/tmp/serverless/"
 SOCK_EXT = ".sock"


### PR DESCRIPTION
Patched calls to getsockopt and setsockopt reduce overhead of unhandled logging.

Closes #50 