### PR TITLE
fix: fix migrate script

### DIFF
--- a/junction/control/webctl.cc
+++ b/junction/control/webctl.cc
@@ -360,9 +360,12 @@ void MigrationServer(rt::TCPQueue &q) {
         LOG(ERR) << "migration restore failed: " << p.error();
       } else {
         LOG(INFO) << "migration restore succeeded, pid=" << (*p)->get_pid();
-        if (timings().migration_restore_start && timings().migration_restore_done) {
+        if (timings().migration_restore_start &&
+            timings().migration_restore_done) {
           LOG(INFO) << "migration receiver: restore to RunThreads took "
-                    << (*timings().migration_restore_done - *timings().migration_restore_start).Microseconds()
+                    << (*timings().migration_restore_done -
+                        *timings().migration_restore_start)
+                           .Microseconds()
                     << " us";
         }
       }

--- a/junction/control/webctl.cc
+++ b/junction/control/webctl.cc
@@ -2,6 +2,7 @@
 
 #include "junction/base/finally.h"
 #include "junction/base/string.h"
+#include "junction/base/time.h"
 #include "junction/bindings/log.h"
 #include "junction/bindings/net.h"
 #include "junction/bindings/thread.h"
@@ -261,6 +262,7 @@ bool HandlePS(ControlConn &c, const ctl_schema::PSRequest *req) {
 bool HandleMigrateStopAndCopy(ControlConn &c,
                               const ctl_schema::MigrateRequest *req) {
   LOG(INFO) << "handling stop-and-copy migration for pid " << req->pid();
+  Time t0 = Time::Now();
 
   std::shared_ptr<Process> p = Process::Find(req->pid());
   if (!p) {
@@ -278,9 +280,15 @@ bool HandleMigrateStopAndCopy(ControlConn &c,
     if (!c.SendError(msg.str())) LOG(WARN) << "ctl: failed to send error";
     return false;
   }
+  Time t1 = Time::Now();
+  LOG(INFO) << "migration sender: TCP connect took " << (t1 - t0).Microseconds()
+            << " us";
 
   p->JobControlStop();
   p->WaitForFullStop();
+  Time t2 = Time::Now();
+  LOG(INFO) << "migration sender: stop took " << (t2 - t1).Microseconds()
+            << " us";
   auto resume = finally([&] { p->DoExit(0); });
 
   if (Status<void> ret = SnapshotProcToELFStream(p.get(), *conn); !ret) {
@@ -289,6 +297,9 @@ bool HandleMigrateStopAndCopy(ControlConn &c,
     if (!c.SendError(msg.str())) LOG(WARN) << "ctl: failed to send error";
     return false;
   }
+  Time t3 = Time::Now();
+  LOG(INFO) << "migration sender: total (connect+stop+snapshot) took "
+            << (t3 - t0).Microseconds() << " us";
 
   if (!c.SendSuccess()) LOG(WARN) << "ctl: failed to send success";
   return false;

--- a/junction/control/webctl.cc
+++ b/junction/control/webctl.cc
@@ -360,6 +360,11 @@ void MigrationServer(rt::TCPQueue &q) {
         LOG(ERR) << "migration restore failed: " << p.error();
       } else {
         LOG(INFO) << "migration restore succeeded, pid=" << (*p)->get_pid();
+        if (timings().migration_restore_start && timings().migration_restore_done) {
+          LOG(INFO) << "migration receiver: restore to RunThreads took "
+                    << (*timings().migration_restore_done - *timings().migration_restore_start).Microseconds()
+                    << " us";
+        }
       }
     });
   }

--- a/junction/samples/migration/counter_service.cc
+++ b/junction/samples/migration/counter_service.cc
@@ -12,6 +12,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <csignal>
@@ -22,6 +23,10 @@
 static int counter = 0;
 
 static void handle_client(int fd) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  long long us = (long long)ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
+
   char buf[64];
   ssize_t n = read(fd, buf, sizeof(buf) - 1);
   if (n <= 0) return;
@@ -36,6 +41,8 @@ static void handle_client(int fd) {
   } else {
     snprintf(resp, sizeof(resp), "ERR\n");
   }
+  fprintf(stdout, "request '%.*s' at %lld us\n", (int)(n - 1), buf, us);
+  fflush(stdout);
   write(fd, resp, strlen(resp));
 }
 

--- a/junction/snapshot/snapshot.h
+++ b/junction/snapshot/snapshot.h
@@ -49,6 +49,8 @@ struct StartupTimings {
   std::optional<Time> restore_data_start;
   std::optional<Time> first_function_start;
   std::optional<Time> first_function_end;
+  std::optional<Time> migration_restore_start;
+  std::optional<Time> migration_restore_done;
 
   Duration CaladanStartTime() {
     assert(junction_main_start);

--- a/junction/snapshot/snapshot_elf.cc
+++ b/junction/snapshot/snapshot_elf.cc
@@ -151,7 +151,8 @@ Status<void> WriteElfIovecs(MemoryMap &mm, SnapshotContext &ctx,
   size_t elf_bytes = 0;
   for (const auto &iov : elf_iovecs) elf_bytes += iov.iov_len;
 
-  if (Status<void> r = WriteU64LE(out, elf_bytes); !r) return r;
+  uint64_t elf_bytes_le = elf_bytes;  // little-endian on x86
+  elf_iovecs.insert(elf_iovecs.begin(), {&elf_bytes_le, sizeof(elf_bytes_le)});
   if (Status<void> r = WritevFull(out, elf_iovecs); !r) return r;
 
   LOG(INFO) << "migration: ELF bytes transferred: " << elf_bytes << " ("

--- a/junction/snapshot/snapshot_elf.cc
+++ b/junction/snapshot/snapshot_elf.cc
@@ -219,9 +219,8 @@ Status<void> SnapshotProcToELFStream(Process *p, VectoredWriter &out) {
     SerializeUnixSocketState(ar);
   }
   Time t1 = Time::Now();
-  LOG(INFO) << "migration sender: serialize took "
-            << (t1 - t0).Microseconds() << " us ("
-            << metadata_buf.size() << " bytes)";
+  LOG(INFO) << "migration sender: serialize took " << (t1 - t0).Microseconds()
+            << " us (" << metadata_buf.size() << " bytes)";
 
   if (Status<void> ret =
           WriteU8(out, static_cast<uint8_t>(MigrationType::kStopAndCopy));
@@ -231,13 +230,15 @@ Status<void> SnapshotProcToELFStream(Process *p, VectoredWriter &out) {
   iovec meta_iov = {metadata_buf.data(), metadata_buf.size()};
   if (Status<void> ret = WritevFull(out, {&meta_iov, 1}); !ret) return ret;
 
-  if (Status<void> ret = SnapshotElfToStream(p->get_mem_map(), GetSnapshotContext(), out); !ret)
+  if (Status<void> ret =
+          SnapshotElfToStream(p->get_mem_map(), GetSnapshotContext(), out);
+      !ret)
     return ret;
   Time t2 = Time::Now();
-  LOG(INFO) << "migration sender: transfer took "
-            << (t2 - t1).Microseconds() << " us";
-  LOG(INFO) << "migration sender: total took "
-            << (t2 - t0).Microseconds() << " us";
+  LOG(INFO) << "migration sender: transfer took " << (t2 - t1).Microseconds()
+            << " us";
+  LOG(INFO) << "migration sender: total took " << (t2 - t0).Microseconds()
+            << " us";
   return {};
 }
 
@@ -419,8 +420,8 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
   Time t4 = Time::Now();
   LOG(INFO) << "migration receiver: ELF deserialize took "
             << (t4 - t3).Microseconds() << " us";
-  LOG(INFO) << "migration receiver: total took "
-            << (t4 - t0).Microseconds() << " us";
+  LOG(INFO) << "migration receiver: total took " << (t4 - t0).Microseconds()
+            << " us";
 
   if (unlikely(GetCfg().mem_trace())) p->get_mem_map().EnableTracing(*p.get());
 

--- a/junction/snapshot/snapshot_elf.cc
+++ b/junction/snapshot/snapshot_elf.cc
@@ -200,6 +200,7 @@ Status<void> SnapshotProcToELFStream(Process *p, VectoredWriter &out) {
   auto f = finally([] { EndSnapshotContext(); });
 
   // Serialize metadata into a buffer so we can length-prefix it.
+  Time t0 = Time::Now();
   std::vector<std::byte> metadata_buf;
   {
     rt::RuntimeLibcGuard guard;
@@ -217,6 +218,10 @@ Status<void> SnapshotProcToELFStream(Process *p, VectoredWriter &out) {
     ar(p->shared_from_this());
     SerializeUnixSocketState(ar);
   }
+  Time t1 = Time::Now();
+  LOG(INFO) << "migration sender: serialize took "
+            << (t1 - t0).Microseconds() << " us ("
+            << metadata_buf.size() << " bytes)";
 
   if (Status<void> ret =
           WriteU8(out, static_cast<uint8_t>(MigrationType::kStopAndCopy));
@@ -225,10 +230,15 @@ Status<void> SnapshotProcToELFStream(Process *p, VectoredWriter &out) {
   if (Status<void> ret = WriteU64LE(out, metadata_buf.size()); !ret) return ret;
   iovec meta_iov = {metadata_buf.data(), metadata_buf.size()};
   if (Status<void> ret = WritevFull(out, {&meta_iov, 1}); !ret) return ret;
-  LOG(INFO) << "migration: metadata bytes transferred: " << metadata_buf.size()
-            << " (" << (metadata_buf.size() / 1024) << " KiB)";
 
-  return SnapshotElfToStream(p->get_mem_map(), GetSnapshotContext(), out);
+  if (Status<void> ret = SnapshotElfToStream(p->get_mem_map(), GetSnapshotContext(), out); !ret)
+    return ret;
+  Time t2 = Time::Now();
+  LOG(INFO) << "migration sender: transfer took "
+            << (t2 - t1).Microseconds() << " us";
+  LOG(INFO) << "migration sender: total took "
+            << (t2 - t0).Microseconds() << " us";
+  return {};
 }
 
 Status<void> SnapshotPidToELF(pid_t pid, std::string_view metadata_path,
@@ -304,6 +314,8 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELF(
 // Stream format: [8-byte metadata length LE][metadata bytes][ELF bytes]
 Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
     VectoredReader &in) {
+  Time t0 = Time::Now();
+
   // Read and dispatch on migration type.
   uint8_t migration_type = 0;
   iovec type_iov = {&migration_type, sizeof(migration_type)};
@@ -329,6 +341,9 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
     if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
       return MakeError(ret);
   }
+  Time t1 = Time::Now();
+  LOG(INFO) << "migration receiver: metadata transfer took "
+            << (t1 - t0).Microseconds() << " us (" << metadata_len << " bytes)";
 
   // Deserialize metadata — guard scoped here only, network reads above/below
   // can block and must not run with preemption disabled.
@@ -355,6 +370,9 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
     SerializeUnixSocketState(ar);
     timings().restore_data_start = Time::Now();
   }
+  Time t2 = Time::Now();
+  LOG(INFO) << "migration receiver: metadata deserialize took "
+            << (t2 - t1).Microseconds() << " us";
 
   // Buffer the ELF data into a tmpfile so LoadELF can seek/mmap it.
   Status<KernelFile> tmp =
@@ -362,17 +380,22 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
                        FileMode::kReadWrite, 0600);
   if (unlikely(!tmp)) return MakeError(tmp);
 
+  size_t elf_bytes = 0;
   {
     std::array<std::byte, 65536> buf;
     while (true) {
       iovec iov = {buf.data(), buf.size()};
       Status<size_t> n = in.Readv({&iov, 1});
       if (!n || *n == 0) break;
+      elf_bytes += *n;
       iovec wiov = {buf.data(), *n};
       if (Status<void> ret = WritevFull(*tmp, {&wiov, 1}); !ret)
         return MakeError(ret);
     }
   }
+  Time t3 = Time::Now();
+  LOG(INFO) << "migration receiver: ELF transfer took "
+            << (t3 - t2).Microseconds() << " us (" << elf_bytes << " bytes)";
 
   Status<JunctionFile> elf = JunctionFile::Open(
       p->get_fs(), "/tmp/junction_migrate.elf", 0, FileMode::kRead);
@@ -392,6 +415,11 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
     LOG(ERR) << "Elf load failed (stream restore): " << ret.error();
     return MakeError(ret);
   }
+  Time t4 = Time::Now();
+  LOG(INFO) << "migration receiver: ELF deserialize took "
+            << (t4 - t3).Microseconds() << " us";
+  LOG(INFO) << "migration receiver: total took "
+            << (t4 - t0).Microseconds() << " us";
 
   if (unlikely(GetCfg().mem_trace())) p->get_mem_map().EnableTracing(*p.get());
 

--- a/junction/snapshot/snapshot_elf.cc
+++ b/junction/snapshot/snapshot_elf.cc
@@ -315,6 +315,7 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELF(
 Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
     VectoredReader &in) {
   Time t0 = Time::Now();
+  timings().migration_restore_start = t0;
 
   // Read and dispatch on migration type.
   uint8_t migration_type = 0;
@@ -423,6 +424,7 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
 
   if (unlikely(GetCfg().mem_trace())) p->get_mem_map().EnableTracing(*p.get());
 
+  timings().migration_restore_done = Time::Now();
   p->RunThreads();
   return p;
 }

--- a/junction/snapshot/snapshot_elf.cc
+++ b/junction/snapshot/snapshot_elf.cc
@@ -148,10 +148,12 @@ Status<void> WriteElfIovecs(MemoryMap &mm, SnapshotContext &ctx,
   if (padding > 0) elf_iovecs.emplace_back(zeros.data(), padding);
   elf_iovecs.insert(elf_iovecs.end(), iovs.begin(), iovs.end());
 
-  if (Status<void> r = WritevFull(out, elf_iovecs); !r) return r;
-
   size_t elf_bytes = 0;
   for (const auto &iov : elf_iovecs) elf_bytes += iov.iov_len;
+
+  if (Status<void> r = WriteU64LE(out, elf_bytes); !r) return r;
+  if (Status<void> r = WritevFull(out, elf_iovecs); !r) return r;
+
   LOG(INFO) << "migration: ELF bytes transferred: " << elf_bytes << " ("
             << (elf_bytes / 1024) << " KiB)";
 
@@ -381,18 +383,19 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
                        FileMode::kReadWrite, 0600);
   if (unlikely(!tmp)) return MakeError(tmp);
 
-  size_t elf_bytes = 0;
+  uint64_t elf_bytes;
   {
-    std::array<std::byte, 65536> buf;
-    while (true) {
-      iovec iov = {buf.data(), buf.size()};
-      Status<size_t> n = in.Readv({&iov, 1});
-      if (!n || *n == 0) break;
-      elf_bytes += *n;
-      iovec wiov = {buf.data(), *n};
-      if (Status<void> ret = WritevFull(*tmp, {&wiov, 1}); !ret)
-        return MakeError(ret);
-    }
+    iovec iov = {&elf_bytes, sizeof(elf_bytes)};
+    if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
+      return MakeError(ret);
+  }
+  std::vector<std::byte> elf_buf(elf_bytes);
+  {
+    iovec iov = {elf_buf.data(), elf_bytes};
+    if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
+      return MakeError(ret);
+    if (Status<void> ret = WritevFull(*tmp, {&iov, 1}); !ret)
+      return MakeError(ret);
   }
   Time t3 = Time::Now();
   LOG(INFO) << "migration receiver: ELF transfer took "

--- a/junction/snapshot/snapshot_elf.cc
+++ b/junction/snapshot/snapshot_elf.cc
@@ -148,13 +148,10 @@ Status<void> WriteElfIovecs(MemoryMap &mm, SnapshotContext &ctx,
   if (padding > 0) elf_iovecs.emplace_back(zeros.data(), padding);
   elf_iovecs.insert(elf_iovecs.end(), iovs.begin(), iovs.end());
 
-  size_t elf_bytes = 0;
-  for (const auto &iov : elf_iovecs) elf_bytes += iov.iov_len;
-
-  uint64_t elf_bytes_le = elf_bytes;  // little-endian on x86
-  elf_iovecs.insert(elf_iovecs.begin(), {&elf_bytes_le, sizeof(elf_bytes_le)});
   if (Status<void> r = WritevFull(out, elf_iovecs); !r) return r;
 
+  size_t elf_bytes = 0;
+  for (const auto &iov : elf_iovecs) elf_bytes += iov.iov_len;
   LOG(INFO) << "migration: ELF bytes transferred: " << elf_bytes << " ("
             << (elf_bytes / 1024) << " KiB)";
 
@@ -384,19 +381,18 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
                        FileMode::kReadWrite, 0600);
   if (unlikely(!tmp)) return MakeError(tmp);
 
-  uint64_t elf_bytes;
+  size_t elf_bytes = 0;
   {
-    iovec iov = {&elf_bytes, sizeof(elf_bytes)};
-    if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
-      return MakeError(ret);
-  }
-  std::vector<std::byte> elf_buf(elf_bytes);
-  {
-    iovec iov = {elf_buf.data(), elf_bytes};
-    if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
-      return MakeError(ret);
-    if (Status<void> ret = WritevFull(*tmp, {&iov, 1}); !ret)
-      return MakeError(ret);
+    std::array<std::byte, 65536> buf;
+    while (true) {
+      iovec iov = {buf.data(), buf.size()};
+      Status<size_t> n = in.Readv({&iov, 1});
+      if (!n || *n == 0) break;
+      elf_bytes += *n;
+      iovec wiov = {buf.data(), *n};
+      if (Status<void> ret = WritevFull(*tmp, {&wiov, 1}); !ret)
+        return MakeError(ret);
+    }
   }
   Time t3 = Time::Now();
   LOG(INFO) << "migration receiver: ELF transfer took "

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -93,6 +93,11 @@ def cmd_initiator(port):
                    check=True)
     t_src_down = time.perf_counter()
 
+    # Wait for destination to be ready
+    t_dst_up = wait_for_service(DST_IP, port)
+    wait_us = (t_dst_up - t_src_down) * 1e6
+    print(f"==> wait_for_service took: {wait_us:.1f} us")
+
     # Verify source is down
     print("==> Verifying source is no longer serving (expect error):")
     try:
@@ -100,12 +105,6 @@ def cmd_initiator(port):
         print("WARNING: source still responding!")
     except OSError:
         print("==> Source confirmed down.")
-
-    # Wait for destination to be ready
-    t_wait_start = time.perf_counter()
-    t_dst_up = wait_for_service(DST_IP, port)
-    wait_us = (t_dst_up - t_wait_start) * 1e6
-    print(f"==> wait_for_service took: {wait_us:.1f} us")
 
     downtime_us = (t_dst_up - t_src_down) * 1e6
     total_us = (t_dst_up - t_start) * 1e6

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -46,7 +46,7 @@ def wait_for_service(ip, port, timeout=30):
             send_cmd(ip, port, "GET", timeout=0.1)
             return time.monotonic()
         except OSError:
-            time.sleep(0.01)
+            time.sleep(0.001)
     raise TimeoutError(f"Service at {ip}:{port} did not come up within {timeout}s")
 
 

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -44,7 +44,7 @@ def wait_for_service(ip, port, timeout=30):
     while time.monotonic() < deadline:
         try:
             send_cmd(ip, port, "GET", timeout=0.1)
-            return time.monotonic()
+            return time.perf_counter()
         except OSError:
             time.sleep(0.001)
     raise TimeoutError(f"Service at {ip}:{port} did not come up within {timeout}s")
@@ -88,10 +88,10 @@ def cmd_initiator(port):
     print(f"==> Migrating pid={pid} from {SRC_IP} to {DST_IP}:44")
 
     # Trigger migration and measure
-    t_start = time.monotonic()
+    t_start = time.perf_counter()
     subprocess.run([JUNCTION_CTL, SRC_IP, "migrate", pid, DST_IP, "44"],
                    check=True)
-    t_src_down = time.monotonic()
+    t_src_down = time.perf_counter()
 
     # Verify source is down
     print("==> Verifying source is no longer serving (expect error):")
@@ -104,8 +104,8 @@ def cmd_initiator(port):
     # Wait for destination to be ready
     t_dst_up = wait_for_service(DST_IP, port)
 
-    downtime_ms = (t_dst_up - t_src_down) * 1000
-    total_ms = (t_dst_up - t_start) * 1000
+    downtime_us = (t_dst_up - t_src_down) * 1e6
+    total_us = (t_dst_up - t_start) * 1e6
 
     print("==> Counter state on destination:")
     print(send_cmd(DST_IP, port, "GET"))
@@ -117,8 +117,8 @@ def cmd_initiator(port):
     print("==> Final counter state on destination:")
     print(send_cmd(DST_IP, port, "GET"))
 
-    print(f"\n==> Downtime:           {downtime_ms:.1f} ms")
-    print(f"==> Total migration time: {total_ms:.1f} ms")
+    print(f"\n==> Downtime:             {downtime_us:.1f} us")
+    print(f"==> Total migration time: {total_us:.1f} us")
 
 
 def main():

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -102,7 +102,10 @@ def cmd_initiator(port):
         print("==> Source confirmed down.")
 
     # Wait for destination to be ready
+    t_wait_start = time.perf_counter()
     t_dst_up = wait_for_service(DST_IP, port)
+    wait_us = (t_dst_up - t_wait_start) * 1e6
+    print(f"==> wait_for_service took: {wait_us:.1f} us")
 
     downtime_us = (t_dst_up - t_src_down) * 1e6
     total_us = (t_dst_up - t_start) * 1e6

--- a/scripts/migrate_criu.py
+++ b/scripts/migrate_criu.py
@@ -38,11 +38,11 @@ def send_cmd(ip, port, cmd, timeout=5):
 
 
 def wait_for_service(ip, port, timeout=30):
-    deadline = time.monotonic() + timeout
+    deadline = time.perf_counter() + timeout
     while time.monotonic() < deadline:
         try:
             send_cmd(ip, port, "GET", timeout=0.1)
-            return time.monotonic()
+            return time.perf_counter()
         except OSError:
             time.sleep(0.01)
     raise TimeoutError(f"Service at {ip}:{port} did not come up within {timeout}s")
@@ -103,7 +103,7 @@ def cmd_migrate(port, verbose):
     subprocess.run(["sudo", "mount", "-t", "tmpfs", "none", DUMP_DIR],
                    capture_output=True)
 
-    t_start = time.monotonic()
+    t_start = time.perf_counter()
 
     run([
         "sudo", "criu", "dump",
@@ -112,7 +112,7 @@ def cmd_migrate(port, verbose):
         "--leave-stopped",
         "--page-server", "--address", DST_IP, "--port", str(PAGE_SERVER_PORT),
     ] + v, check=True)
-    t_src_down = time.monotonic()
+    t_src_down = time.perf_counter()
 
     # Measure metadata size (pages already on dst)
     dump_size = sum(


### PR DESCRIPTION
Adds per-phase timing instrumentation to the migration path and fixes incorrect downtime/total time measurements in the benchmark scripts.

Timing instrumentation (snapshot_elf.cc, webctl.cc, snapshot.h):

On the sender, logs are now emitted for: TCP connect time, process stop time, metadata serialize time, ELF transfer time, and total time. On the receiver,
logs cover: metadata transfer, metadata deserialize, ELF transfer, ELF deserialize, total, and restore-to-RunThreads. Two new timestamp fields (
migration_restore_start, migration_restore_done) are added to StartupTimings to support the restore-to-RunThreads measurement.

counter_service.cc also gains per-request timestamps (using CLOCK_MONOTONIC) to correlate request activity with migration events.

scripts/migrate.py bug fix:

wait_for_service was called after a send_cmd(..., timeout=2) on the already-dead source, causing ~2 seconds of blocking to be silently included in both
downtime and total migration time. Fixed by moving wait_for_service to run immediately after the migrate command returns. Also switches all timing to
time.perf_counter() and reports results in microseconds instead of milliseconds.

scripts/migrate_criu.py:

Switches all time.monotonic() calls to time.perf_counter() for consistency with migrate.py.