### PR TITLE
feat: impl scatter copy migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ junction-ctl/src/control_response_generated.rs
 run.202*
 
 .agents
+.kiro

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ junction-ctl/src/control_response_generated.rs
 ._*
 
 run.202*
+
+.agents

--- a/junction-ctl/src/main.rs
+++ b/junction-ctl/src/main.rs
@@ -147,6 +147,8 @@ enum Command {
         pid: u64,
         dest_ip: String,
         dest_port: u16,
+        #[arg(long, default_value_t = false)]
+        scatter_copy: bool,
     },
 }
 
@@ -677,13 +679,13 @@ fn get_stats(uri: &str) -> anyhow::Result<()> {
     }
 }
 
-fn migrate(uri: &str, pid: u64, dest_ip: &str, dest_port: u16) -> anyhow::Result<()> {
+fn migrate(uri: &str, pid: u64, dest_ip: &str, dest_port: u16, scatter_copy: bool) -> anyhow::Result<()> {
     let dest_ip: u32 = dest_ip
         .parse::<std::net::Ipv4Addr>()
         .context("invalid dest_ip")?
         .into();
     let mut fbb = FlatBufferBuilder::new();
-    let inner = MigrateRequest::create(&mut fbb, &MigrateRequestArgs { pid, dest_ip, dest_port });
+    let inner = MigrateRequest::create(&mut fbb, &MigrateRequestArgs { pid, dest_ip, dest_port, scatter_copy });
     let req = Request::create(
         &mut fbb,
         &RequestArgs {
@@ -752,8 +754,8 @@ fn main() -> anyhow::Result<()> {
         Some(Command::Signal { pid, signal: signo }) => signal(uri.as_str(), pid, signo),
         Some(Command::GetStats) => get_stats(uri.as_str()),
         Some(Command::PS) => ps(uri.as_str()),
-        Some(Command::Migrate { pid, dest_ip, dest_port }) => {
-            migrate(uri.as_str(), pid, dest_ip.as_str(), dest_port)
+        Some(Command::Migrate { pid, dest_ip, dest_port, scatter_copy }) => {
+            migrate(uri.as_str(), pid, dest_ip.as_str(), dest_port, scatter_copy)
         }
     }
 }

--- a/junction/control/control_request.fbs
+++ b/junction/control/control_request.fbs
@@ -41,6 +41,7 @@ table MigrateRequest {
     pid: uint64;
     dest_ip: uint32;
     dest_port: uint16;
+    scatter_copy: bool;
 }
 
 table GetStatsRequest {

--- a/junction/control/webctl.cc
+++ b/junction/control/webctl.cc
@@ -261,8 +261,10 @@ bool HandlePS(ControlConn &c, const ctl_schema::PSRequest *req) {
 }
 bool HandleMigrateStopAndCopy(ControlConn &c,
                               const ctl_schema::MigrateRequest *req) {
-  LOG(INFO) << "handling stop-and-copy migration for pid " << req->pid()
-            << " (skip_file_pages=" << GetCfg().skip_file_pages() << ")";
+  bool scatter = req->scatter_copy();
+  LOG(INFO) << "handling migration for pid " << req->pid()
+            << " (skip_file_pages=" << GetCfg().skip_file_pages()
+            << " scatter_copy=" << scatter << ")";
   Time t0 = Time::Now();
 
   std::shared_ptr<Process> p = Process::Find(req->pid());
@@ -292,7 +294,10 @@ bool HandleMigrateStopAndCopy(ControlConn &c,
             << " us";
   auto resume = finally([&] { p->DoExit(0); });
 
-  if (Status<void> ret = SnapshotProcToELFStream(p.get(), *conn); !ret) {
+  Status<void> ret = scatter
+                         ? SnapshotProcToScatterStream(p.get(), *conn)
+                         : SnapshotProcToELFStream(p.get(), *conn);
+  if (!ret) {
     std::ostringstream msg;
     msg << "migrate: snapshot failed: " << ret.error();
     if (!c.SendError(msg.str())) LOG(WARN) << "ctl: failed to send error";

--- a/junction/control/webctl.cc
+++ b/junction/control/webctl.cc
@@ -294,9 +294,8 @@ bool HandleMigrateStopAndCopy(ControlConn &c,
             << " us";
   auto resume = finally([&] { p->DoExit(0); });
 
-  Status<void> ret = scatter
-                         ? SnapshotProcToScatterStream(p.get(), *conn)
-                         : SnapshotProcToELFStream(p.get(), *conn);
+  Status<void> ret = scatter ? SnapshotProcToScatterStream(p.get(), *conn)
+                             : SnapshotProcToELFStream(p.get(), *conn);
   if (!ret) {
     std::ostringstream msg;
     msg << "migrate: snapshot failed: " << ret.error();

--- a/junction/kernel/elf.cc
+++ b/junction/kernel/elf.cc
@@ -112,11 +112,12 @@ Status<void> LoadOneSegment(MemoryMap &mm, JunctionFile &f, off_t map_off,
   if (phdr.flags & kFlagWrite) prot |= PROT_WRITE;
   if (phdr.flags & kFlagRead) prot |= PROT_READ;
 
-  // For migration ELFs (non-relocatable, map_off == 0), paddr encodes the
-  // byte offset within the VMA where file data begins. This supports stack
-  // segments where leading zero pages are trimmed by the sender.
-  // For normal (relocatable) binaries, paddr is ignored.
-  uint64_t data_off = (map_off == 0 && phdr.paddr < phdr.memsz) ? phdr.paddr : 0;
+  // For migration ELFs, paddr encodes the byte offset within the VMA where
+  // file data begins (used for stack trimming). Normal binaries have
+  // paddr == vaddr; migration stack segments have paddr as a small offset
+  // (!= vaddr). Non-stack migration segments have paddr == 0.
+  uint64_t data_off =
+      (phdr.paddr != phdr.vaddr && phdr.paddr < phdr.memsz) ? phdr.paddr : 0;
 
   // Determine the layout.
   uintptr_t start = PageAlignDown(phdr.vaddr + map_off);

--- a/junction/kernel/elf.cc
+++ b/junction/kernel/elf.cc
@@ -112,22 +112,35 @@ Status<void> LoadOneSegment(MemoryMap &mm, JunctionFile &f, off_t map_off,
   if (phdr.flags & kFlagWrite) prot |= PROT_WRITE;
   if (phdr.flags & kFlagRead) prot |= PROT_READ;
 
+  // paddr encodes the byte offset within the VMA where file data begins.
+  // Used for stack segments where leading zero pages are trimmed by the sender.
+  // For all other segments paddr is 0 and the layout is unchanged.
+  uint64_t data_off = phdr.paddr;
+
   // Determine the layout.
   uintptr_t start = PageAlignDown(phdr.vaddr + map_off);
-  uintptr_t file_end = phdr.vaddr + map_off + phdr.filesz;
+  uintptr_t data_start = phdr.vaddr + map_off + data_off;
+  uintptr_t file_end = data_start + phdr.filesz;
   uintptr_t gap_end = PageAlign(file_end);
   uintptr_t mem_end = phdr.vaddr + map_off + phdr.memsz;
 
-  // Map the file part of the segment.
-  if (file_end > start) {
-    Status<void> ret =
-        f.MMapFixed(mm, reinterpret_cast<void *>(start), file_end - start, prot,
-                    MAP_DENYWRITE, PageAlignDown(phdr.offset));
+  // Map the leading anonymous region before file data (trimmed stack pages).
+  if (data_start > start) {
+    Status<void *> ret = mm.MMapAnonymous(reinterpret_cast<void *>(start),
+                                          data_start - start, prot, MAP_FIXED);
     if (unlikely(!ret)) return MakeError(ret);
   }
 
-  // Zero the gap
-  if (gap_end > file_end) {
+  // Map the file part of the segment.
+  if (phdr.filesz > 0) {
+    Status<void> ret = f.MMapFixed(
+        mm, reinterpret_cast<void *>(data_start), file_end - data_start, prot,
+        MAP_DENYWRITE, PageAlignDown(phdr.offset));
+    if (unlikely(!ret)) return MakeError(ret);
+  }
+
+  // Zero the gap between file_end and the next page boundary.
+  if (gap_end > file_end && phdr.filesz > 0) {
     if ((prot & PROT_WRITE) == 0) {
       Status<void> ret =
           mm.MProtect(reinterpret_cast<void *>(PageAlignDown(file_end)),

--- a/junction/kernel/elf.cc
+++ b/junction/kernel/elf.cc
@@ -127,7 +127,7 @@ Status<void> LoadOneSegment(MemoryMap &mm, JunctionFile &f, off_t map_off,
   uintptr_t mem_end = phdr.vaddr + map_off + phdr.memsz;
 
   // Map the leading anonymous region before file data (trimmed stack pages).
-  if (data_start > start) {
+  if (data_off > 0 && data_start > start) {
     Status<void *> ret = mm.MMapAnonymous(reinterpret_cast<void *>(start),
                                           data_start - start, prot, MAP_FIXED);
     if (unlikely(!ret)) return MakeError(ret);
@@ -135,8 +135,9 @@ Status<void> LoadOneSegment(MemoryMap &mm, JunctionFile &f, off_t map_off,
 
   // Map the file part of the segment.
   if (phdr.filesz > 0) {
+    uintptr_t map_start = data_off > 0 ? data_start : start;
     Status<void> ret = f.MMapFixed(
-        mm, reinterpret_cast<void *>(data_start), file_end - data_start, prot,
+        mm, reinterpret_cast<void *>(map_start), file_end - map_start, prot,
         MAP_DENYWRITE, PageAlignDown(phdr.offset));
     if (unlikely(!ret)) return MakeError(ret);
   }

--- a/junction/kernel/elf.cc
+++ b/junction/kernel/elf.cc
@@ -136,9 +136,9 @@ Status<void> LoadOneSegment(MemoryMap &mm, JunctionFile &f, off_t map_off,
   // Map the file part of the segment.
   if (phdr.filesz > 0) {
     uintptr_t map_start = data_off > 0 ? data_start : start;
-    Status<void> ret = f.MMapFixed(
-        mm, reinterpret_cast<void *>(map_start), file_end - map_start, prot,
-        MAP_DENYWRITE, PageAlignDown(phdr.offset));
+    Status<void> ret = f.MMapFixed(mm, reinterpret_cast<void *>(map_start),
+                                   file_end - map_start, prot, MAP_DENYWRITE,
+                                   PageAlignDown(phdr.offset));
     if (unlikely(!ret)) return MakeError(ret);
   }
 

--- a/junction/kernel/elf.cc
+++ b/junction/kernel/elf.cc
@@ -112,10 +112,11 @@ Status<void> LoadOneSegment(MemoryMap &mm, JunctionFile &f, off_t map_off,
   if (phdr.flags & kFlagWrite) prot |= PROT_WRITE;
   if (phdr.flags & kFlagRead) prot |= PROT_READ;
 
-  // paddr encodes the byte offset within the VMA where file data begins.
-  // Used for stack segments where leading zero pages are trimmed by the sender.
-  // For all other segments paddr is 0 and the layout is unchanged.
-  uint64_t data_off = phdr.paddr;
+  // For migration ELFs (non-relocatable, map_off == 0), paddr encodes the
+  // byte offset within the VMA where file data begins. This supports stack
+  // segments where leading zero pages are trimmed by the sender.
+  // For normal (relocatable) binaries, paddr is ignored.
+  uint64_t data_off = (map_off == 0 && phdr.paddr < phdr.memsz) ? phdr.paddr : 0;
 
   // Determine the layout.
   uintptr_t start = PageAlignDown(phdr.vaddr + map_off);

--- a/junction/kernel/proc.cc
+++ b/junction/kernel/proc.cc
@@ -225,7 +225,6 @@ Thread::~Thread() {
 bool Thread::IsStopped() const { return proc_->is_stopped(); }
 
 Status<void> Thread::DropUnusedStack() {
-  return {};
   assert(get_process().is_fully_stopped());
   // If the thread has indicated that signals cannot be delivered on it then we
   // shouldn't assume that we can clobber above rsp.

--- a/junction/samples/migration/CMakeLists.txt
+++ b/junction/samples/migration/CMakeLists.txt
@@ -31,3 +31,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/caladan_migration_dst.config
 add_executable(counter_service
   counter_service.cc
 )
+
+add_executable(kv_service
+  kv_service.cc
+)

--- a/junction/samples/migration/kv_service.cc
+++ b/junction/samples/migration/kv_service.cc
@@ -1,0 +1,155 @@
+// kv_service.cc - stateful key-value microservice for migration testing.
+//
+// In-memory key-value store with configurable heap footprint.
+// Listens on a TCP port, accepts connections, and responds to commands:
+//   "GET <key>\n"              -> "VALUE <data>\n" or "NOT_FOUND\n"
+//   "SET <key> <value>\n"      -> "OK\n"
+//   "DEL <key>\n"              -> "OK\n" or "NOT_FOUND\n"
+//   "STATS\n"                  -> "KEYS <n> BYTES <b>\n"
+//   "CHECKSUM\n"               -> "CHECKSUM <hex>\n"
+//   "LOAD <n> <vsize>\n"       -> "LOADED <n>\n"
+//
+// Usage: kv_service <port> [num_keys] [value_size]
+//   port        TCP port to listen on
+//   num_keys    pre-populate this many keys on startup (default: 0)
+//   value_size  byte size of each pre-populated value (default: 1024)
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <unordered_map>
+
+static std::unordered_map<std::string, std::string> store;
+
+static void load_data(int n, int vsize) {
+  std::string val(vsize, '\0');
+  for (int i = 0; i < n; i++) {
+    // Deterministic fill so checksum is reproducible.
+    for (int j = 0; j < vsize; j++) val[j] = (char)((i + j) & 0xff);
+    store["key_" + std::to_string(i)] = val;
+  }
+}
+
+static size_t estimate_bytes() {
+  size_t total = 0;
+  for (auto &kv : store) total += kv.first.size() + kv.second.size();
+  return total;
+}
+
+static uint32_t compute_checksum() {
+  // FNV-1a over all key-value pairs in iteration order is
+  // non-deterministic (unordered_map), so hash values sorted by key.
+  // For speed, just XOR-rotate over all bytes.
+  uint32_t h = 0x811c9dc5;
+  for (auto &kv : store) {
+    for (char c : kv.first) h = (h ^ (uint8_t)c) * 0x01000193;
+    for (char c : kv.second) h = (h ^ (uint8_t)c) * 0x01000193;
+  }
+  return h;
+}
+
+static void send_resp(int fd, const char *resp, size_t len) {
+  size_t sent = 0;
+  while (sent < len) {
+    ssize_t n = write(fd, resp + sent, len - sent);
+    if (n <= 0) break;
+    sent += n;
+  }
+}
+
+static void handle_client(int fd) {
+  // Read up to 4 KB per request (enough for SET with reasonable values).
+  char buf[4096];
+  ssize_t n = read(fd, buf, sizeof(buf) - 1);
+  if (n <= 0) return;
+  buf[n] = '\0';
+  // Strip trailing newline.
+  if (n > 0 && buf[n - 1] == '\n') buf[--n] = '\0';
+
+  char resp[256];
+
+  if (strncmp(buf, "GET ", 4) == 0) {
+    auto it = store.find(buf + 4);
+    if (it != store.end()) {
+      // For large values, build response dynamically.
+      std::string r = "VALUE " + it->second + "\n";
+      send_resp(fd, r.c_str(), r.size());
+      return;
+    }
+    snprintf(resp, sizeof(resp), "NOT_FOUND\n");
+  } else if (strncmp(buf, "SET ", 4) == 0) {
+    // SET <key> <value>
+    char *space = strchr(buf + 4, ' ');
+    if (space) {
+      *space = '\0';
+      store[buf + 4] = std::string(space + 1);
+      snprintf(resp, sizeof(resp), "OK\n");
+    } else {
+      snprintf(resp, sizeof(resp), "ERR bad SET syntax\n");
+    }
+  } else if (strncmp(buf, "DEL ", 4) == 0) {
+    snprintf(resp, sizeof(resp),
+             store.erase(buf + 4) ? "OK\n" : "NOT_FOUND\n");
+  } else if (strncmp(buf, "STATS", 5) == 0) {
+    snprintf(resp, sizeof(resp), "KEYS %zu BYTES %zu\n", store.size(),
+             estimate_bytes());
+  } else if (strncmp(buf, "CHECKSUM", 8) == 0) {
+    snprintf(resp, sizeof(resp), "CHECKSUM %08x\n", compute_checksum());
+  } else if (strncmp(buf, "LOAD ", 5) == 0) {
+    int num = 0, vsize = 1024;
+    sscanf(buf + 5, "%d %d", &num, &vsize);
+    load_data(num, vsize);
+    snprintf(resp, sizeof(resp), "LOADED %d\n", num);
+  } else {
+    snprintf(resp, sizeof(resp), "ERR unknown command\n");
+  }
+  send_resp(fd, resp, strlen(resp));
+}
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    fprintf(stderr, "usage: %s <port> [num_keys] [value_size]\n", argv[0]);
+    return EXIT_FAILURE;
+  }
+
+  int port = atoi(argv[1]);
+  int num_keys = argc > 2 ? atoi(argv[2]) : 0;
+  int vsize = argc > 3 ? atoi(argv[3]) : 1024;
+
+  if (num_keys > 0) {
+    fprintf(stdout, "pre-loading %d keys (%d bytes each)...\n", num_keys,
+            vsize);
+    fflush(stdout);
+    load_data(num_keys, vsize);
+  }
+
+  int srv = socket(AF_INET, SOCK_STREAM, 0);
+  int opt = 1;
+  setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+  struct sockaddr_in addr = {};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(port);
+  bind(srv, (struct sockaddr *)&addr, sizeof(addr));
+  listen(srv, 16);
+
+  fprintf(stdout, "kv_service listening on port %d (%zu keys, %zu bytes)\n",
+          port, store.size(), estimate_bytes());
+  fflush(stdout);
+
+  while (1) {
+    int fd = accept(srv, nullptr, nullptr);
+    if (fd < 0) continue;
+    handle_client(fd);
+    close(fd);
+  }
+}

--- a/junction/samples/migration/kv_service.cc
+++ b/junction/samples/migration/kv_service.cc
@@ -1,6 +1,8 @@
 // kv_service.cc - stateful key-value microservice for migration testing.
 //
-// In-memory key-value store with configurable heap footprint.
+// In-memory key-value store with configurable heap footprint, using only
+// C APIs (no libstdc++) for migration compatibility.
+//
 // Listens on a TCP port, accepts connections, and responds to commands:
 //   "GET <key>\n"              -> "VALUE <data>\n" or "NOT_FOUND\n"
 //   "SET <key> <value>\n"      -> "OK\n"
@@ -24,36 +26,138 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <string>
-#include <unordered_map>
 
-static std::unordered_map<std::string, std::string> store;
+// Simple open-addressing hash table (no libstdc++ dependency).
+struct Entry {
+  char *key;
+  char *value;
+  size_t vlen;
+};
 
-static void load_data(int n, int vsize) {
-  std::string val(vsize, '\0');
-  for (int i = 0; i < n; i++) {
-    // Deterministic fill so checksum is reproducible.
-    for (int j = 0; j < vsize; j++) val[j] = (char)((i + j) & 0xff);
-    store["key_" + std::to_string(i)] = val;
+static Entry *table;
+static size_t table_cap;
+static size_t table_count;
+static size_t total_bytes;
+
+static void table_init(size_t cap) {
+  table_cap = cap;
+  table = (Entry *)calloc(cap, sizeof(Entry));
+  table_count = 0;
+  total_bytes = 0;
+}
+
+static size_t hash_str(const char *s) {
+  size_t h = 0x811c9dc5;
+  for (; *s; s++) h = (h ^ (uint8_t)*s) * 0x01000193;
+  return h;
+}
+
+static Entry *table_find(const char *key) {
+  size_t idx = hash_str(key) % table_cap;
+  for (size_t i = 0; i < table_cap; i++) {
+    size_t pos = (idx + i) % table_cap;
+    if (!table[pos].key) return nullptr;
+    if (strcmp(table[pos].key, key) == 0) return &table[pos];
+  }
+  return nullptr;
+}
+
+static void table_grow(void);
+
+static void table_set(const char *key, const char *value, size_t vlen) {
+  if (table_count * 2 >= table_cap) table_grow();
+  size_t idx = hash_str(key) % table_cap;
+  for (size_t i = 0; i < table_cap; i++) {
+    size_t pos = (idx + i) % table_cap;
+    if (!table[pos].key) {
+      table[pos].key = strdup(key);
+      table[pos].value = (char *)malloc(vlen);
+      memcpy(table[pos].value, value, vlen);
+      table[pos].vlen = vlen;
+      table_count++;
+      total_bytes += strlen(key) + vlen;
+      return;
+    }
+    if (strcmp(table[pos].key, key) == 0) {
+      total_bytes -= table[pos].vlen;
+      free(table[pos].value);
+      table[pos].value = (char *)malloc(vlen);
+      memcpy(table[pos].value, value, vlen);
+      table[pos].vlen = vlen;
+      total_bytes += vlen;
+      return;
+    }
   }
 }
 
-static size_t estimate_bytes() {
-  size_t total = 0;
-  for (auto &kv : store) total += kv.first.size() + kv.second.size();
-  return total;
+static void table_grow(void) {
+  Entry *old = table;
+  size_t old_cap = table_cap;
+  table_cap *= 2;
+  table = (Entry *)calloc(table_cap, sizeof(Entry));
+  table_count = 0;
+  total_bytes = 0;
+  for (size_t i = 0; i < old_cap; i++) {
+    if (old[i].key) {
+      table_set(old[i].key, old[i].value, old[i].vlen);
+      free(old[i].key);
+      free(old[i].value);
+    }
+  }
+  free(old);
 }
 
-static uint32_t compute_checksum() {
-  // FNV-1a over all key-value pairs in iteration order is
-  // non-deterministic (unordered_map), so hash values sorted by key.
-  // For speed, just XOR-rotate over all bytes.
+static int table_del(const char *key) {
+  Entry *e = table_find(key);
+  if (!e) return 0;
+  total_bytes -= strlen(e->key) + e->vlen;
+  free(e->key);
+  free(e->value);
+  e->key = nullptr;
+  e->value = nullptr;
+  e->vlen = 0;
+  table_count--;
+  // Rehash subsequent entries to fix probe chain.
+  size_t pos = (size_t)(e - table);
+  for (size_t i = 1; i < table_cap; i++) {
+    size_t next = (pos + i) % table_cap;
+    if (!table[next].key) break;
+    char *k = table[next].key;
+    char *v = table[next].value;
+    size_t vl = table[next].vlen;
+    total_bytes -= strlen(k) + vl;
+    table[next].key = nullptr;
+    table[next].value = nullptr;
+    table[next].vlen = 0;
+    table_count--;
+    table_set(k, v, vl);
+    free(k);
+    free(v);
+  }
+  return 1;
+}
+
+static uint32_t compute_checksum(void) {
   uint32_t h = 0x811c9dc5;
-  for (auto &kv : store) {
-    for (char c : kv.first) h = (h ^ (uint8_t)c) * 0x01000193;
-    for (char c : kv.second) h = (h ^ (uint8_t)c) * 0x01000193;
+  for (size_t i = 0; i < table_cap; i++) {
+    if (!table[i].key) continue;
+    for (const char *c = table[i].key; *c; c++)
+      h = (h ^ (uint8_t)*c) * 0x01000193;
+    for (size_t j = 0; j < table[i].vlen; j++)
+      h = (h ^ (uint8_t)table[i].value[j]) * 0x01000193;
   }
   return h;
+}
+
+static void load_data(int n, int vsize) {
+  char keybuf[32];
+  char *val = (char *)malloc(vsize);
+  for (int i = 0; i < n; i++) {
+    for (int j = 0; j < vsize; j++) val[j] = (char)((i + j) & 0xff);
+    snprintf(keybuf, sizeof(keybuf), "key_%d", i);
+    table_set(keybuf, val, vsize);
+  }
+  free(val);
 }
 
 static void send_resp(int fd, const char *resp, size_t len) {
@@ -66,41 +170,43 @@ static void send_resp(int fd, const char *resp, size_t len) {
 }
 
 static void handle_client(int fd) {
-  // Read up to 4 KB per request (enough for SET with reasonable values).
   char buf[4096];
   ssize_t n = read(fd, buf, sizeof(buf) - 1);
   if (n <= 0) return;
   buf[n] = '\0';
-  // Strip trailing newline.
   if (n > 0 && buf[n - 1] == '\n') buf[--n] = '\0';
 
   char resp[256];
 
   if (strncmp(buf, "GET ", 4) == 0) {
-    auto it = store.find(buf + 4);
-    if (it != store.end()) {
-      // For large values, build response dynamically.
-      std::string r = "VALUE " + it->second + "\n";
-      send_resp(fd, r.c_str(), r.size());
+    Entry *e = table_find(buf + 4);
+    if (e) {
+      // "VALUE " + value + "\n"
+      size_t rlen = 6 + e->vlen + 1;
+      char *r = (char *)malloc(rlen);
+      memcpy(r, "VALUE ", 6);
+      memcpy(r + 6, e->value, e->vlen);
+      r[rlen - 1] = '\n';
+      send_resp(fd, r, rlen);
+      free(r);
       return;
     }
     snprintf(resp, sizeof(resp), "NOT_FOUND\n");
   } else if (strncmp(buf, "SET ", 4) == 0) {
-    // SET <key> <value>
     char *space = strchr(buf + 4, ' ');
     if (space) {
       *space = '\0';
-      store[buf + 4] = std::string(space + 1);
+      size_t vlen = n - (space + 1 - buf);
+      table_set(buf + 4, space + 1, vlen);
       snprintf(resp, sizeof(resp), "OK\n");
     } else {
       snprintf(resp, sizeof(resp), "ERR bad SET syntax\n");
     }
   } else if (strncmp(buf, "DEL ", 4) == 0) {
-    snprintf(resp, sizeof(resp),
-             store.erase(buf + 4) ? "OK\n" : "NOT_FOUND\n");
+    snprintf(resp, sizeof(resp), table_del(buf + 4) ? "OK\n" : "NOT_FOUND\n");
   } else if (strncmp(buf, "STATS", 5) == 0) {
-    snprintf(resp, sizeof(resp), "KEYS %zu BYTES %zu\n", store.size(),
-             estimate_bytes());
+    snprintf(resp, sizeof(resp), "KEYS %zu BYTES %zu\n", table_count,
+             total_bytes);
   } else if (strncmp(buf, "CHECKSUM", 8) == 0) {
     snprintf(resp, sizeof(resp), "CHECKSUM %08x\n", compute_checksum());
   } else if (strncmp(buf, "LOAD ", 5) == 0) {
@@ -124,6 +230,8 @@ int main(int argc, char *argv[]) {
   int num_keys = argc > 2 ? atoi(argv[2]) : 0;
   int vsize = argc > 3 ? atoi(argv[3]) : 1024;
 
+  table_init(1024);
+
   if (num_keys > 0) {
     fprintf(stdout, "pre-loading %d keys (%d bytes each)...\n", num_keys,
             vsize);
@@ -143,7 +251,7 @@ int main(int argc, char *argv[]) {
   listen(srv, 16);
 
   fprintf(stdout, "kv_service listening on port %d (%zu keys, %zu bytes)\n",
-          port, store.size(), estimate_bytes());
+          port, table_count, total_bytes);
   fflush(stdout);
 
   while (1) {

--- a/junction/snapshot/CMakeLists.txt
+++ b/junction/snapshot/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(snapshot
   snapshot.cc
   snapshot_elf.cc
   snapshot_jif.cc
+  snapshot_scatter.cc
 )
 
 target_link_libraries(snapshot

--- a/junction/snapshot/migrate_format.h
+++ b/junction/snapshot/migrate_format.h
@@ -21,7 +21,7 @@ struct MigrateSegment {
   uint64_t vaddr;        // target virtual address
   uint64_t memsz;        // total memory region size
   uint64_t filesz;       // bytes in stream (page data for Load, path len for FileRef)
-  uint64_t file_offset;  // for FileRef: offset into backing file; unused for Load
+  uint64_t file_offset;  // FileRef: offset into backing file; Load: data placement offset (stack trimming)
   uint32_t prot;         // PROT_READ | PROT_WRITE | PROT_EXEC
   uint32_t type;         // kMigrateSegLoad or kMigrateSegFileRef
 };

--- a/junction/snapshot/migrate_format.h
+++ b/junction/snapshot/migrate_format.h
@@ -1,0 +1,31 @@
+// migrate_format.h - wire format for scatter-copy migration
+
+#pragma once
+
+#include <cstdint>
+
+namespace junction {
+
+#pragma pack(push, 1)
+
+struct MigrateHeader {
+  uint32_t segment_count;
+};
+
+enum : uint32_t {
+  kMigrateSegLoad = 1,
+  kMigrateSegFileRef = 2,
+};
+
+struct MigrateSegment {
+  uint64_t vaddr;        // target virtual address
+  uint64_t memsz;        // total memory region size
+  uint64_t filesz;       // bytes in stream (page data for Load, path len for FileRef)
+  uint64_t file_offset;  // for FileRef: offset into backing file; unused for Load
+  uint32_t prot;         // PROT_READ | PROT_WRITE | PROT_EXEC
+  uint32_t type;         // kMigrateSegLoad or kMigrateSegFileRef
+};
+
+#pragma pack(pop)
+
+}  // namespace junction

--- a/junction/snapshot/migrate_format.h
+++ b/junction/snapshot/migrate_format.h
@@ -18,10 +18,12 @@ enum : uint32_t {
 };
 
 struct MigrateSegment {
-  uint64_t vaddr;        // target virtual address
-  uint64_t memsz;        // total memory region size
-  uint64_t filesz;       // bytes in stream (page data for Load, path len for FileRef)
-  uint64_t file_offset;  // FileRef: offset into backing file; Load: data placement offset (stack trimming)
+  uint64_t vaddr;  // target virtual address
+  uint64_t memsz;  // total memory region size
+  uint64_t
+      filesz;  // bytes in stream (page data for Load, path len for FileRef)
+  uint64_t file_offset;  // FileRef: offset into backing file; Load: data
+                         // placement offset (stack trimming)
   uint32_t prot;         // PROT_READ | PROT_WRITE | PROT_EXEC
   uint32_t type;         // kMigrateSegLoad or kMigrateSegFileRef
 };

--- a/junction/snapshot/snapshot.cc
+++ b/junction/snapshot/snapshot.cc
@@ -11,6 +11,7 @@ extern "C" {
 #include "junction/base/error.h"
 #include "junction/base/finally.h"
 #include "junction/fs/file.h"
+#include "junction/fs/fs.h"
 #include "junction/fs/junction_file.h"
 #include "junction/fs/memfs/memfs.h"
 #include "junction/kernel/elf.h"
@@ -79,6 +80,94 @@ Status<void> TakeSnapshot(Process *p) {
   if (GetCfg().jif())
     return SnapshotProcToJIF(p, prefix + ".jm", prefix + ".jif");
   return SnapshotProcToELF(p, prefix + ".metadata", prefix + ".elf");
+}
+
+Status<std::vector<std::byte>> SerializeSnapshotMetadata(Process *p) {
+  std::vector<std::byte> buf;
+  {
+    rt::RuntimeLibcGuard guard;
+    struct VecWriter {
+      std::vector<std::byte> &buf;
+      Status<size_t> Write(std::span<const std::byte> src) {
+        buf.insert(buf.end(), src.begin(), src.end());
+        return src.size();
+      }
+    } vw{buf};
+    StreamBufferWriter<VecWriter> sbw(vw);
+    std::ostream outstream(&sbw);
+    cereal::BinaryOutputArchive ar(outstream);
+    if (Status<void> ret = FSSnapshot(ar); !ret) return MakeError(ret);
+    ar(p->shared_from_this());
+    SerializeUnixSocketState(ar);
+  }
+  return buf;
+}
+
+Status<std::shared_ptr<Process>> DeserializeSnapshotMetadata(
+    std::span<const std::byte> buf) {
+  std::shared_ptr<Process> p;
+  {
+    rt::RuntimeLibcGuard guard;
+    struct VecReader {
+      std::span<const std::byte> remaining;
+      Status<size_t> Read(std::span<std::byte> dst) {
+        size_t n = std::min(dst.size(), remaining.size());
+        std::copy_n(remaining.begin(), n, dst.begin());
+        remaining = remaining.subspan(n);
+        return n ? n : Status<size_t>(MakeError(EUNEXPECTEDEOF));
+      }
+    } vr{buf};
+    StreamBufferReader<VecReader> sbr(vr);
+    std::istream instream(&sbr);
+    cereal::BinaryInputArchive ar(instream);
+
+    if (Status<void> ret = FSRestore(ar); unlikely(!ret)) return MakeError(ret);
+    timings().restore_metadata_start = Time::Now();
+
+    ar(p);
+    SerializeUnixSocketState(ar);
+    timings().restore_data_start = Time::Now();
+  }
+  return p;
+}
+
+Status<void> WriteStreamPrefix(VectoredWriter &out, MigrationType type,
+                               std::span<const std::byte> metadata) {
+  if (Status<void> ret = WriteU8(out, static_cast<uint8_t>(type)); !ret)
+    return ret;
+  uint64_t len = metadata.size();
+  if (Status<void> ret = WriteU64LE(out, len); !ret) return ret;
+  iovec iov = {const_cast<std::byte *>(metadata.data()), metadata.size()};
+  return WritevFull(out, {&iov, 1});
+}
+
+Status<std::pair<MigrationType, std::vector<std::byte>>> ReadStreamPrefix(
+    VectoredReader &in) {
+  // Read migration type byte.
+  uint8_t type_byte = 0;
+  {
+    iovec iov = {&type_byte, sizeof(type_byte)};
+    if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
+      return MakeError(ret);
+  }
+
+  // Read metadata length prefix.
+  uint64_t metadata_len = 0;
+  {
+    iovec iov = {&metadata_len, sizeof(metadata_len)};
+    if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
+      return MakeError(ret);
+  }
+
+  // Read metadata into buffer.
+  std::vector<std::byte> buf(metadata_len);
+  {
+    iovec iov = {buf.data(), buf.size()};
+    if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
+      return MakeError(ret);
+  }
+
+  return std::make_pair(static_cast<MigrationType>(type_byte), std::move(buf));
 }
 
 }  // namespace junction

--- a/junction/snapshot/snapshot.h
+++ b/junction/snapshot/snapshot.h
@@ -10,6 +10,8 @@ extern "C" {
 #include "lib/caladan/runtime/defs.h"
 }
 
+#include <array>
+#include <cstring>
 #include <span>
 #include <string>
 #include <string_view>
@@ -18,6 +20,7 @@ extern "C" {
 #include "junction/base/arch.h"
 #include "junction/base/bits.h"
 #include "junction/base/error.h"
+#include "junction/base/io.h"
 #include "junction/base/time.h"
 #include "junction/bindings/net.h"
 #include "junction/kernel/elf.h"
@@ -142,7 +145,58 @@ Status<void> TakeSnapshot(Process *p);
  */
 enum class MigrationType : uint8_t {
   kStopAndCopy = 1,
+  kScatterCopy = 2,
 };
+
+/**
+ * Shared migration stream helpers
+ */
+
+// Write a uint64 in little-endian to a vectored writer.
+inline Status<void> WriteU64LE(VectoredWriter &w, uint64_t v) {
+  iovec iov = {&v, sizeof(v)};
+  return WritevFull(w, {&iov, 1});
+}
+
+// Write a single byte to a vectored writer.
+inline Status<void> WriteU8(VectoredWriter &w, uint8_t v) {
+  iovec iov = {&v, sizeof(v)};
+  return WritevFull(w, {&iov, 1});
+}
+
+// Returns true if the page at mem matches the file content at file_offset.
+inline bool PageMatchesFile(int fd, off_t file_offset, const void *mem) {
+  alignas(64) std::array<std::byte, kPageSize> buf;
+  ssize_t n = ksys_pread(fd, buf.data(), kPageSize, file_offset);
+  if (n != static_cast<ssize_t>(kPageSize)) return false;
+  return std::memcmp(mem, buf.data(), kPageSize) == 0;
+}
+
+// Returns true if every page of the VMA matches the backing file content.
+inline bool VMAMatchesFile(int fd, const VMArea &vma) {
+  for (uintptr_t page = vma.start; page < vma.start + vma.Length();
+       page += kPageSize) {
+    off_t file_off = vma.offset + (page - vma.start);
+    if (!PageMatchesFile(fd, file_off, reinterpret_cast<void *>(page)))
+      return false;
+  }
+  return true;
+}
+
+// Serialize process metadata (FS + Process + Unix sockets) into a byte buffer.
+Status<std::vector<std::byte>> SerializeSnapshotMetadata(Process *p);
+
+// Deserialize process metadata from a byte buffer. Returns the Process.
+Status<std::shared_ptr<Process>> DeserializeSnapshotMetadata(
+    std::span<const std::byte> buf);
+
+// Write the stream prefix: [1-byte type][8-byte metadata_len][metadata].
+Status<void> WriteStreamPrefix(VectoredWriter &out, MigrationType type,
+                               std::span<const std::byte> metadata);
+
+// Read the stream prefix: type byte + length-prefixed metadata buffer.
+Status<std::pair<MigrationType, std::vector<std::byte>>> ReadStreamPrefix(
+    VectoredReader &in);
 
 /**
  * ELF utilities
@@ -154,16 +208,26 @@ Status<void> SnapshotProcToELF(Process *p, std::string_view metadata_path,
                                std::string_view elf_path);
 
 // Snapshots a process directly to a stream (diskless).
-// Stream format: [1-byte MigrationType][8-byte metadata length LE][metadata
-// bytes][ELF bytes]
+// Stream format (kStopAndCopy): [1-byte MigrationType][8-byte metadata length
+// LE][metadata bytes][ELF bytes]
 Status<void> SnapshotProcToELFStream(Process *p, VectoredWriter &out);
 
 Status<std::shared_ptr<Process>> RestoreProcessFromELF(
     std::string_view metadata_path, std::string_view elf_path);
 
-// Restores a process from a stream produced by SnapshotProcToELFStream.
+// Restores a process from a stream (dispatches on MigrationType).
 Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
     VectoredReader &in);
+
+/**
+ * Scatter-copy migration (skip ELF format entirely)
+ * Stream format (kScatterCopy): [1-byte MigrationType][8-byte metadata length
+ * LE][metadata bytes][MigrateHeader][MigrateSegment × N][kLoad page
+ * data][kFileRef path strings]
+ */
+Status<void> SnapshotProcToScatterStream(Process *p, VectoredWriter &out);
+Status<std::shared_ptr<Process>> RestoreFromScatterStream(
+    VectoredReader &in, std::shared_ptr<Process> p);
 
 /**
  * JIF utilities

--- a/junction/snapshot/snapshot_elf.cc
+++ b/junction/snapshot/snapshot_elf.cc
@@ -98,7 +98,8 @@ GetElfPHDRs(MemoryMap &mm, SnapshotContext &ctx) {
     }
 
     // Stacks grow downward: trim leading zero pages and only transfer the
-    // live portion at the top, recording the offset into vaddr/memsz.
+    // live portion, but preserve the full VMA bounds so the stack can grow.
+    // paddr stores the offset from vaddr where file data begins.
     if (vma.type == VMType::kStack && filesz) {
       size_t stack_off =
           GetStackMinOffset(reinterpret_cast<void *>(vma.start), filesz);
@@ -110,10 +111,10 @@ GetElfPHDRs(MemoryMap &mm, SnapshotContext &ctx) {
           .type = kPTypeLoad,
           .flags = flags,
           .offset = offset,
-          .vaddr = live_start,
-          .paddr = 0,
+          .vaddr = vma.start,
+          .paddr = stack_off,
           .filesz = live_filesz,
-          .memsz = live_len,
+          .memsz = vma.Length(),
           .align = kPageSize,
       };
       phdrs.push_back(phdr);
@@ -122,7 +123,7 @@ GetElfPHDRs(MemoryMap &mm, SnapshotContext &ctx) {
                    << live_start << " type=" << vma.TypeString()
                    << " prot=" << vma.ProtString()
                    << " filesz=" << std::dec << live_filesz
-                   << " memsz=" << live_len;
+                   << " memsz=" << vma.Length();
         offset += live_filesz;
         iovs.emplace_back(reinterpret_cast<void *>(live_start), live_filesz);
       }

--- a/junction/snapshot/snapshot_elf.cc
+++ b/junction/snapshot/snapshot_elf.cc
@@ -120,6 +120,7 @@ GetElfPHDRs(MemoryMap &mm, SnapshotContext &ctx) {
       if (live_filesz) {
         LOG(DEBUG) << "migration sender: Load PHDR vaddr=0x" << std::hex
                    << live_start << " type=" << vma.TypeString()
+                   << " prot=" << vma.ProtString()
                    << " filesz=" << std::dec << live_filesz
                    << " memsz=" << live_len;
         offset += live_filesz;
@@ -147,6 +148,7 @@ GetElfPHDRs(MemoryMap &mm, SnapshotContext &ctx) {
     if (filesz) {
       LOG(DEBUG) << "migration sender: Load PHDR vaddr=0x" << std::hex
                  << vma.start << " type=" << vma.TypeString()
+                 << " prot=" << vma.ProtString()
                  << " filesz=" << std::dec << filesz
                  << " memsz=" << vma.Length();
       offset += filesz;

--- a/junction/snapshot/snapshot_elf.cc
+++ b/junction/snapshot/snapshot_elf.cc
@@ -121,9 +121,8 @@ GetElfPHDRs(MemoryMap &mm, SnapshotContext &ctx) {
       if (live_filesz) {
         LOG(DEBUG) << "migration sender: Load PHDR vaddr=0x" << std::hex
                    << live_start << " type=" << vma.TypeString()
-                   << " prot=" << vma.ProtString()
-                   << " filesz=" << std::dec << live_filesz
-                   << " memsz=" << vma.Length();
+                   << " prot=" << vma.ProtString() << " filesz=" << std::dec
+                   << live_filesz << " memsz=" << vma.Length();
         offset += live_filesz;
         iovs.emplace_back(reinterpret_cast<void *>(live_start), live_filesz);
       }
@@ -149,9 +148,8 @@ GetElfPHDRs(MemoryMap &mm, SnapshotContext &ctx) {
     if (filesz) {
       LOG(DEBUG) << "migration sender: Load PHDR vaddr=0x" << std::hex
                  << vma.start << " type=" << vma.TypeString()
-                 << " prot=" << vma.ProtString()
-                 << " filesz=" << std::dec << filesz
-                 << " memsz=" << vma.Length();
+                 << " prot=" << vma.ProtString() << " filesz=" << std::dec
+                 << filesz << " memsz=" << vma.Length();
       offset += filesz;
       iovs.emplace_back(reinterpret_cast<void *>(vma.start), filesz);
     }
@@ -295,8 +293,8 @@ Status<void> SnapshotProcToELFStream(Process *p, VectoredWriter &out) {
   LOG(INFO) << "migration sender: serialize took " << (t1 - t0).Microseconds()
             << " us (" << metadata_buf->size() << " bytes)";
 
-  if (Status<void> ret = WriteStreamPrefix(out, MigrationType::kStopAndCopy,
-                                           *metadata_buf);
+  if (Status<void> ret =
+          WriteStreamPrefix(out, MigrationType::kStopAndCopy, *metadata_buf);
       !ret)
     return ret;
 

--- a/junction/snapshot/snapshot_elf.cc
+++ b/junction/snapshot/snapshot_elf.cc
@@ -27,35 +27,8 @@ namespace junction {
 
 namespace {
 
-// Writes a uint64 in little-endian to the writer.
-Status<void> WriteU64LE(VectoredWriter &w, uint64_t v) {
-  iovec iov = {&v, sizeof(v)};
-  return WritevFull(w, {&iov, 1});
-}
-
-Status<void> WriteU8(VectoredWriter &w, uint8_t v) {
-  iovec iov = {&v, sizeof(v)};
-  return WritevFull(w, {&iov, 1});
-}
-
 // Returns true if the page at mem matches the file content at file_offset.
-bool PageMatchesFile(int fd, off_t file_offset, const void *mem) {
-  alignas(64) std::array<std::byte, kPageSize> buf;
-  ssize_t n = ksys_pread(fd, buf.data(), kPageSize, file_offset);
-  if (n != static_cast<ssize_t>(kPageSize)) return false;
-  return std::memcmp(mem, buf.data(), kPageSize) == 0;
-}
-
-// Returns true if every page of the VMA matches the backing file content.
-bool VMAMatchesFile(int fd, const VMArea &vma) {
-  for (uintptr_t page = vma.start; page < vma.start + vma.Length();
-       page += kPageSize) {
-    off_t file_off = vma.offset + (page - vma.start);
-    if (!PageMatchesFile(fd, file_off, reinterpret_cast<void *>(page)))
-      return false;
-  }
-  return true;
-}
+// (Defined in snapshot.h as inline)
 
 Status<std::tuple<std::vector<elf_phdr>, std::vector<iovec>,
                   std::vector<std::string>>>
@@ -306,43 +279,23 @@ Status<void> SnapshotProcToELF(Process *p, std::string_view metadata_path,
 }
 
 // Snapshots a process to a stream without touching the filesystem.
-// Stream format: [8-byte metadata length LE][metadata bytes][ELF bytes]
 Status<void> SnapshotProcToELFStream(Process *p, VectoredWriter &out) {
   LOG(INFO) << "snapshotting proc " << p->get_pid() << " to stream";
 
   StartSnapshotContext();
   auto f = finally([] { EndSnapshotContext(); });
 
-  // Serialize metadata into a buffer so we can length-prefix it.
   Time t0 = Time::Now();
-  std::vector<std::byte> metadata_buf;
-  {
-    rt::RuntimeLibcGuard guard;
-    struct VecWriter {
-      std::vector<std::byte> &buf;
-      Status<size_t> Write(std::span<const std::byte> src) {
-        buf.insert(buf.end(), src.begin(), src.end());
-        return src.size();
-      }
-    } vw{metadata_buf};
-    StreamBufferWriter<VecWriter> sbw(vw);
-    std::ostream outstream(&sbw);
-    cereal::BinaryOutputArchive ar(outstream);
-    if (Status<void> ret = FSSnapshot(ar); !ret) return ret;
-    ar(p->shared_from_this());
-    SerializeUnixSocketState(ar);
-  }
+  Status<std::vector<std::byte>> metadata_buf = SerializeSnapshotMetadata(p);
+  if (!metadata_buf) return MakeError(metadata_buf);
   Time t1 = Time::Now();
   LOG(INFO) << "migration sender: serialize took " << (t1 - t0).Microseconds()
-            << " us (" << metadata_buf.size() << " bytes)";
+            << " us (" << metadata_buf->size() << " bytes)";
 
-  if (Status<void> ret =
-          WriteU8(out, static_cast<uint8_t>(MigrationType::kStopAndCopy));
+  if (Status<void> ret = WriteStreamPrefix(out, MigrationType::kStopAndCopy,
+                                           *metadata_buf);
       !ret)
     return ret;
-  if (Status<void> ret = WriteU64LE(out, metadata_buf.size()); !ret) return ret;
-  iovec meta_iov = {metadata_buf.data(), metadata_buf.size()};
-  if (Status<void> ret = WritevFull(out, {&meta_iov, 1}); !ret) return ret;
 
   if (Status<void> ret =
           SnapshotElfToStream(p->get_mem_map(), GetSnapshotContext(), out);
@@ -425,72 +378,39 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELF(
   return p;
 }
 
-// Restores a process from a stream produced by SnapshotProcToELFStream.
-// Stream format: [8-byte metadata length LE][metadata bytes][ELF bytes]
+// Restores a process from a migration stream. Dispatches on MigrationType.
 Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
     VectoredReader &in) {
   Time t0 = Time::Now();
   timings().migration_restore_start = t0;
 
-  // Read and dispatch on migration type.
-  uint8_t migration_type = 0;
-  iovec type_iov = {&migration_type, sizeof(migration_type)};
-  if (Status<void> ret = ReadvFull(in, {&type_iov, 1}); !ret)
-    return MakeError(ret);
-  if (migration_type != static_cast<uint8_t>(MigrationType::kStopAndCopy)) {
-    LOG(ERR) << "unsupported migration type: " << migration_type;
-    return MakeError(EINVAL);
-  }
-
-  // Read metadata length prefix.
-  uint64_t metadata_len = 0;
-  {
-    iovec iov = {&metadata_len, sizeof(metadata_len)};
-    if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
-      return MakeError(ret);
-  }
-
-  // Read metadata into a buffer.
-  std::vector<std::byte> metadata_buf(metadata_len);
-  {
-    iovec iov = {metadata_buf.data(), metadata_buf.size()};
-    if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
-      return MakeError(ret);
-  }
+  // Read stream prefix: type + metadata.
+  auto prefix = ReadStreamPrefix(in);
+  if (!prefix) return MakeError(prefix);
+  auto &[type, metadata_buf] = *prefix;
   Time t1 = Time::Now();
   LOG(INFO) << "migration receiver: metadata transfer took "
-            << (t1 - t0).Microseconds() << " us (" << metadata_len << " bytes)";
+            << (t1 - t0).Microseconds() << " us (" << metadata_buf.size()
+            << " bytes)";
 
-  // Deserialize metadata — guard scoped here only, network reads above/below
-  // can block and must not run with preemption disabled.
-  std::shared_ptr<Process> p;
-  {
-    rt::RuntimeLibcGuard guard;
-    struct VecReader {
-      std::span<const std::byte> remaining;
-      Status<size_t> Read(std::span<std::byte> dst) {
-        size_t n = std::min(dst.size(), remaining.size());
-        std::copy_n(remaining.begin(), n, dst.begin());
-        remaining = remaining.subspan(n);
-        return n ? n : Status<size_t>(MakeError(EUNEXPECTEDEOF));
-      }
-    } vr{metadata_buf};
-    StreamBufferReader<VecReader> sbr(vr);
-    std::istream instream(&sbr);
-    cereal::BinaryInputArchive ar(instream);
-
-    if (Status<void> ret = FSRestore(ar); unlikely(!ret)) return MakeError(ret);
-    timings().restore_metadata_start = Time::Now();
-
-    ar(p);
-    SerializeUnixSocketState(ar);
-    timings().restore_data_start = Time::Now();
-  }
+  // Deserialize metadata.
+  auto p = DeserializeSnapshotMetadata(metadata_buf);
+  if (!p) return MakeError(p);
   Time t2 = Time::Now();
   LOG(INFO) << "migration receiver: metadata deserialize took "
             << (t2 - t1).Microseconds() << " us";
 
-  // Buffer the ELF data into a tmpfile so LoadELF can seek/mmap it.
+  // Dispatch on migration type.
+  if (type == MigrationType::kScatterCopy) {
+    return RestoreFromScatterStream(in, std::move(*p));
+  }
+
+  if (type != MigrationType::kStopAndCopy) {
+    LOG(ERR) << "unsupported migration type: " << static_cast<int>(type);
+    return MakeError(EINVAL);
+  }
+
+  // ELF restore path: buffer to tmpfile, then LoadELF.
   Status<KernelFile> tmp =
       KernelFile::Open("/tmp/junction_migrate.elf", O_CREAT | O_TRUNC,
                        FileMode::kReadWrite, 0600);
@@ -514,12 +434,12 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
             << (t3 - t2).Microseconds() << " us (" << elf_bytes << " bytes)";
 
   Status<JunctionFile> elf = JunctionFile::Open(
-      p->get_fs(), "/tmp/junction_migrate.elf", 0, FileMode::kRead);
+      (*p)->get_fs(), "/tmp/junction_migrate.elf", 0, FileMode::kRead);
   if (unlikely(!elf)) return MakeError(elf);
 
   MemoryMap mm(nullptr, kMemoryMappingSize);
   mm.MarkAsFake();
-  Status<elf_data> ret = LoadELF(mm, *elf, p->get_fs());
+  Status<elf_data> ret = LoadELF(mm, *elf, (*p)->get_fs());
   if (GetCfg().restore_populate()) {
     mm.ForEachVMA([](const VMArea &vma) {
       if (!(vma.prot & PROT_READ)) return;
@@ -537,11 +457,12 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
   LOG(INFO) << "migration receiver: total took " << (t4 - t0).Microseconds()
             << " us";
 
-  if (unlikely(GetCfg().mem_trace())) p->get_mem_map().EnableTracing(*p.get());
+  if (unlikely(GetCfg().mem_trace()))
+    (*p)->get_mem_map().EnableTracing(*(*p).get());
 
   timings().migration_restore_done = Time::Now();
-  p->RunThreads();
-  return p;
+  (*p)->RunThreads();
+  return std::move(*p);
 }
 
 }  // namespace junction

--- a/junction/snapshot/snapshot_elf.cc
+++ b/junction/snapshot/snapshot_elf.cc
@@ -394,7 +394,7 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
   Time t1 = Time::Now();
   LOG(INFO) << "migration receiver: metadata transfer took "
             << (t1 - t0).Microseconds() << " us (" << metadata_buf.size()
-            << " bytes)";
+            << " bytes, " << (metadata_buf.size() / 1024) << " KiB)";
 
   // Deserialize metadata.
   auto p = DeserializeSnapshotMetadata(metadata_buf);
@@ -434,7 +434,8 @@ Status<std::shared_ptr<Process>> RestoreProcessFromELFStream(
   }
   Time t3 = Time::Now();
   LOG(INFO) << "migration receiver: ELF transfer took "
-            << (t3 - t2).Microseconds() << " us (" << elf_bytes << " bytes)";
+            << (t3 - t2).Microseconds() << " us (" << elf_bytes << " bytes, "
+            << (elf_bytes / 1024) << " KiB)";
 
   Status<JunctionFile> elf = JunctionFile::Open(
       (*p)->get_fs(), "/tmp/junction_migrate.elf", 0, FileMode::kRead);

--- a/junction/snapshot/snapshot_scatter.cc
+++ b/junction/snapshot/snapshot_scatter.cc
@@ -264,7 +264,8 @@ Status<std::shared_ptr<Process>> RestoreFromScatterStream(
   size_t data_bytes = 0;
   for (const auto &iov : load_iovs) data_bytes += iov.iov_len;
   LOG(INFO) << "scatter receiver: data transfer took "
-            << (t1 - t0).Microseconds() << " us (" << data_bytes << " bytes)";
+            << (t1 - t0).Microseconds() << " us (" << data_bytes << " bytes, "
+            << (data_bytes / 1024) << " KiB)";
 
   // Phase 3: Zero BSS gaps and set final protections.
   for (const auto &seg : segs) {

--- a/junction/snapshot/snapshot_scatter.cc
+++ b/junction/snapshot/snapshot_scatter.cc
@@ -87,11 +87,11 @@ BuildMigrateSegments(MemoryMap &mm, SnapshotContext &ctx) {
       size_t live_filesz =
           PageAlign(GetMinSize(reinterpret_cast<void *>(live_start), live_len));
       segs.push_back({.vaddr = vma.start,
-                       .memsz = vma.Length(),
-                       .filesz = live_filesz,
-                       .file_offset = stack_off,
-                       .prot = prot,
-                       .type = kMigrateSegLoad});
+                      .memsz = vma.Length(),
+                      .filesz = live_filesz,
+                      .file_offset = stack_off,
+                      .prot = prot,
+                      .type = kMigrateSegLoad});
       if (live_filesz) {
         LOG(DEBUG) << "scatter sender: Load vaddr=0x" << std::hex << live_start
                    << " type=" << vma.TypeString() << " filesz=" << std::dec
@@ -105,11 +105,11 @@ BuildMigrateSegments(MemoryMap &mm, SnapshotContext &ctx) {
     filesz = PageAlign(GetMinSize(reinterpret_cast<void *>(vma.start), filesz));
 
     segs.push_back({.vaddr = vma.start,
-                     .memsz = vma.Length(),
-                     .filesz = filesz,
-                     .file_offset = 0,
-                     .prot = prot,
-                     .type = kMigrateSegLoad});
+                    .memsz = vma.Length(),
+                    .filesz = filesz,
+                    .file_offset = 0,
+                    .prot = prot,
+                    .type = kMigrateSegLoad});
     if (filesz) {
       LOG(DEBUG) << "scatter sender: Load vaddr=0x" << std::hex << vma.start
                  << " type=" << vma.TypeString() << " filesz=" << std::dec
@@ -122,11 +122,11 @@ BuildMigrateSegments(MemoryMap &mm, SnapshotContext &ctx) {
   for (const FSMemoryArea &area : ctx.mem_areas_) {
     size_t saved_area = PageAlign(GetMinSize(area.ptr, area.in_use_size));
     segs.push_back({.vaddr = reinterpret_cast<uint64_t>(area.ptr),
-                     .memsz = area.max_size,
-                     .filesz = saved_area,
-                     .file_offset = 0,
-                     .prot = PROT_READ | PROT_WRITE,
-                     .type = kMigrateSegLoad});
+                    .memsz = area.max_size,
+                    .filesz = saved_area,
+                    .file_offset = 0,
+                    .prot = PROT_READ | PROT_WRITE,
+                    .type = kMigrateSegLoad});
     if (saved_area) iovs.emplace_back(area.ptr, saved_area);
   }
 
@@ -189,8 +189,8 @@ Status<void> SnapshotProcToScatterStream(Process *p, VectoredWriter &out) {
   LOG(INFO) << "scatter sender: serialize took " << (t1 - t0).Microseconds()
             << " us (" << metadata_buf->size() << " bytes)";
 
-  if (Status<void> ret = WriteStreamPrefix(out, MigrationType::kScatterCopy,
-                                           *metadata_buf);
+  if (Status<void> ret =
+          WriteStreamPrefix(out, MigrationType::kScatterCopy, *metadata_buf);
       !ret)
     return ret;
 
@@ -239,9 +239,9 @@ Status<std::shared_ptr<Process>> RestoreFromScatterStream(
     if (seg.type != kMigrateSegLoad) continue;
     if (seg.memsz == 0) continue;
 
-    Status<void *> ret = mm.MMapAnonymous(
-        reinterpret_cast<void *>(seg.vaddr), seg.memsz,
-        PROT_READ | PROT_WRITE, MAP_FIXED);
+    Status<void *> ret =
+        mm.MMapAnonymous(reinterpret_cast<void *>(seg.vaddr), seg.memsz,
+                         PROT_READ | PROT_WRITE, MAP_FIXED);
     if (!ret) {
       LOG(ERR) << "scatter receiver: MMapAnonymous failed vaddr=0x" << std::hex
                << seg.vaddr << " memsz=" << std::dec << seg.memsz;
@@ -316,9 +316,9 @@ Status<std::shared_ptr<Process>> RestoreFromScatterStream(
     }
 
     int prot = static_cast<int>(seg.prot);
-    if (Status<void> r = ref->MMapFixed(
-            mm, reinterpret_cast<void *>(seg.vaddr), seg.memsz, prot,
-            MAP_DENYWRITE, static_cast<off_t>(seg.file_offset));
+    if (Status<void> r = ref->MMapFixed(mm, reinterpret_cast<void *>(seg.vaddr),
+                                        seg.memsz, prot, MAP_DENYWRITE,
+                                        static_cast<off_t>(seg.file_offset));
         !r) {
       LOG(ERR) << "scatter receiver: FileRef MMapFixed failed for " << path;
       return MakeError(r);

--- a/junction/snapshot/snapshot_scatter.cc
+++ b/junction/snapshot/snapshot_scatter.cc
@@ -86,16 +86,16 @@ BuildMigrateSegments(MemoryMap &mm, SnapshotContext &ctx) {
       size_t live_len = vma.Length() - stack_off;
       size_t live_filesz =
           PageAlign(GetMinSize(reinterpret_cast<void *>(live_start), live_len));
-      segs.push_back({.vaddr = live_start,
-                       .memsz = live_len,
+      segs.push_back({.vaddr = vma.start,
+                       .memsz = vma.Length(),
                        .filesz = live_filesz,
-                       .file_offset = 0,
+                       .file_offset = stack_off,
                        .prot = prot,
                        .type = kMigrateSegLoad});
       if (live_filesz) {
         LOG(DEBUG) << "scatter sender: Load vaddr=0x" << std::hex << live_start
                    << " type=" << vma.TypeString() << " filesz=" << std::dec
-                   << live_filesz << " memsz=" << live_len;
+                   << live_filesz << " memsz=" << vma.Length();
         iovs.emplace_back(reinterpret_cast<void *>(live_start), live_filesz);
       }
       continue;
@@ -249,7 +249,8 @@ Status<std::shared_ptr<Process>> RestoreFromScatterStream(
     }
 
     if (seg.filesz > 0)
-      load_iovs.emplace_back(reinterpret_cast<void *>(seg.vaddr), seg.filesz);
+      load_iovs.emplace_back(
+          reinterpret_cast<void *>(seg.vaddr + seg.file_offset), seg.filesz);
   }
 
   // Phase 2: Single scatter-read for all kLoad data.
@@ -271,7 +272,7 @@ Status<std::shared_ptr<Process>> RestoreFromScatterStream(
 
     // Zero partial page between filesz and page-aligned end.
     if (seg.filesz < seg.memsz) {
-      uintptr_t file_end = seg.vaddr + seg.filesz;
+      uintptr_t file_end = seg.vaddr + seg.file_offset + seg.filesz;
       uintptr_t gap_end = PageAlign(file_end);
       if (gap_end > file_end && gap_end <= seg.vaddr + seg.memsz)
         std::memset(reinterpret_cast<void *>(file_end), 0, gap_end - file_end);

--- a/junction/snapshot/snapshot_scatter.cc
+++ b/junction/snapshot/snapshot_scatter.cc
@@ -1,0 +1,345 @@
+#include <cstring>
+#include <vector>
+
+extern "C" {
+#include <fcntl.h>
+}
+
+#include "junction/base/error.h"
+#include "junction/base/finally.h"
+#include "junction/base/io.h"
+#include "junction/bindings/log.h"
+#include "junction/fs/fs.h"
+#include "junction/fs/junction_file.h"
+#include "junction/junction.h"
+#include "junction/kernel/ksys.h"
+#include "junction/kernel/proc.h"
+#include "junction/limits.h"
+#include "junction/snapshot/migrate_format.h"
+#include "junction/snapshot/snapshot.h"
+
+namespace junction {
+
+namespace {
+
+// Builds MigrateSegment descriptors and parallel iovecs from process VMAs.
+// kLoad segments first, kFileRef segments appended after.
+Status<std::tuple<std::vector<MigrateSegment>, std::vector<iovec>,
+                  std::vector<std::string>>>
+BuildMigrateSegments(MemoryMap &mm, SnapshotContext &ctx) {
+  const std::vector<VMArea> vmas = mm.get_vmas();
+  std::vector<MigrateSegment> segs;
+  std::vector<iovec> iovs;
+  std::vector<std::string> path_strs;
+
+  std::vector<MigrateSegment> fileref_segs;
+  std::vector<iovec> fileref_iovs;
+
+  for (const VMArea &vma : vmas) {
+    uint32_t prot = 0;
+    if (vma.prot & PROT_EXEC) prot |= PROT_EXEC;
+    if (vma.prot & PROT_WRITE) prot |= PROT_WRITE;
+    if (vma.prot & PROT_READ) prot |= PROT_READ;
+
+    // Skip-file-pages: send path instead of page data.
+    if (GetCfg().skip_file_pages() && vma.type == VMType::kFile &&
+        !(vma.prot & PROT_WRITE)) {
+      Status<std::string> path =
+          vma.file->get_dent_ref().GetPathStr(FSRoot::GetGlobalRoot());
+      if (path) {
+        int fd = ksys_open(path->c_str(), O_RDONLY, 0);
+        if (fd >= 0) {
+          auto close_fd = finally([fd] { ksys_close(fd); });
+          if (VMAMatchesFile(fd, vma)) {
+            size_t pathsz = path->size() + 1;
+            path_strs.push_back(std::move(*path));
+            fileref_segs.push_back({
+                .vaddr = vma.start,
+                .memsz = vma.Length(),
+                .filesz = pathsz,
+                .file_offset = static_cast<uint64_t>(vma.offset),
+                .prot = prot,
+                .type = kMigrateSegFileRef,
+            });
+            fileref_iovs.emplace_back(
+                const_cast<char *>(path_strs.back().c_str()), pathsz);
+            continue;
+          }
+        }
+      }
+    }
+
+    size_t filesz = vma.DataLength();
+
+    // Make memory readable if needed for transfer.
+    if (filesz && !(vma.prot & PROT_READ)) {
+      auto ret = KernelMProtect(reinterpret_cast<void *>(vma.start), filesz,
+                                vma.prot | PROT_READ);
+      if (!ret) return MakeError(ret);
+    }
+
+    // Stack trimming.
+    if (vma.type == VMType::kStack && filesz) {
+      size_t stack_off =
+          GetStackMinOffset(reinterpret_cast<void *>(vma.start), filesz);
+      uintptr_t live_start = vma.start + stack_off;
+      size_t live_len = vma.Length() - stack_off;
+      size_t live_filesz =
+          PageAlign(GetMinSize(reinterpret_cast<void *>(live_start), live_len));
+      segs.push_back({.vaddr = live_start,
+                       .memsz = live_len,
+                       .filesz = live_filesz,
+                       .file_offset = 0,
+                       .prot = prot,
+                       .type = kMigrateSegLoad});
+      if (live_filesz) {
+        LOG(DEBUG) << "scatter sender: Load vaddr=0x" << std::hex << live_start
+                   << " type=" << vma.TypeString() << " filesz=" << std::dec
+                   << live_filesz << " memsz=" << live_len;
+        iovs.emplace_back(reinterpret_cast<void *>(live_start), live_filesz);
+      }
+      continue;
+    }
+
+    // Trailing zero trimming.
+    filesz = PageAlign(GetMinSize(reinterpret_cast<void *>(vma.start), filesz));
+
+    segs.push_back({.vaddr = vma.start,
+                     .memsz = vma.Length(),
+                     .filesz = filesz,
+                     .file_offset = 0,
+                     .prot = prot,
+                     .type = kMigrateSegLoad});
+    if (filesz) {
+      LOG(DEBUG) << "scatter sender: Load vaddr=0x" << std::hex << vma.start
+                 << " type=" << vma.TypeString() << " filesz=" << std::dec
+                 << filesz << " memsz=" << vma.Length();
+      iovs.emplace_back(reinterpret_cast<void *>(vma.start), filesz);
+    }
+  }
+
+  // FS memory areas.
+  for (const FSMemoryArea &area : ctx.mem_areas_) {
+    size_t saved_area = PageAlign(GetMinSize(area.ptr, area.in_use_size));
+    segs.push_back({.vaddr = reinterpret_cast<uint64_t>(area.ptr),
+                     .memsz = area.max_size,
+                     .filesz = saved_area,
+                     .file_offset = 0,
+                     .prot = PROT_READ | PROT_WRITE,
+                     .type = kMigrateSegLoad});
+    if (saved_area) iovs.emplace_back(area.ptr, saved_area);
+  }
+
+  // Append FileRef segments after all Load segments.
+  for (size_t i = 0; i < fileref_segs.size(); i++) {
+    LOG(DEBUG) << "scatter sender: FileRef path="
+               << std::string_view(
+                      static_cast<const char *>(fileref_iovs[i].iov_base),
+                      fileref_segs[i].filesz - 1)
+               << " vaddr=0x" << std::hex << fileref_segs[i].vaddr
+               << " memsz=" << std::dec << fileref_segs[i].memsz;
+    segs.push_back(fileref_segs[i]);
+    iovs.push_back(fileref_iovs[i]);
+  }
+
+  return std::make_tuple(std::move(segs), std::move(iovs),
+                         std::move(path_strs));
+}
+
+// Writes scatter-copy segment data: [MigrateHeader][segments][data].
+Status<void> WriteMigrateStream(MemoryMap &mm, SnapshotContext &ctx,
+                                VectoredWriter &out) {
+  auto ret = BuildMigrateSegments(mm, ctx);
+  if (!ret) return MakeError(ret);
+  auto &[segs, iovs, path_strs] = *ret;
+
+  MigrateHeader hdr = {.segment_count = static_cast<uint32_t>(segs.size())};
+
+  std::vector<iovec> all_iovs;
+  all_iovs.reserve(2 + iovs.size());
+  all_iovs.emplace_back(&hdr, sizeof(hdr));
+  if (!segs.empty())
+    all_iovs.emplace_back(segs.data(), segs.size() * sizeof(MigrateSegment));
+  all_iovs.insert(all_iovs.end(), iovs.begin(), iovs.end());
+
+  if (Status<void> r = WritevFull(out, all_iovs); !r) return r;
+
+  size_t total = sizeof(hdr) + segs.size() * sizeof(MigrateSegment);
+  for (const auto &iov : iovs) total += iov.iov_len;
+  LOG(INFO) << "scatter migration: bytes transferred: " << total << " ("
+            << (total / 1024) << " KiB)";
+
+  return RestoreVMAProtections(mm);
+}
+
+}  // namespace
+
+// Sender: snapshot process to scatter-copy stream.
+Status<void> SnapshotProcToScatterStream(Process *p, VectoredWriter &out) {
+  LOG(INFO) << "scatter-copy snapshotting proc " << p->get_pid()
+            << " to stream";
+
+  StartSnapshotContext();
+  auto f = finally([] { EndSnapshotContext(); });
+
+  Time t0 = Time::Now();
+  Status<std::vector<std::byte>> metadata_buf = SerializeSnapshotMetadata(p);
+  if (!metadata_buf) return MakeError(metadata_buf);
+  Time t1 = Time::Now();
+  LOG(INFO) << "scatter sender: serialize took " << (t1 - t0).Microseconds()
+            << " us (" << metadata_buf->size() << " bytes)";
+
+  if (Status<void> ret = WriteStreamPrefix(out, MigrationType::kScatterCopy,
+                                           *metadata_buf);
+      !ret)
+    return ret;
+
+  if (Status<void> ret =
+          WriteMigrateStream(p->get_mem_map(), GetSnapshotContext(), out);
+      !ret)
+    return ret;
+  Time t2 = Time::Now();
+  LOG(INFO) << "scatter sender: transfer took " << (t2 - t1).Microseconds()
+            << " us";
+  LOG(INFO) << "scatter sender: total took " << (t2 - t0).Microseconds()
+            << " us";
+  return {};
+}
+
+// Receiver: restore from scatter-copy stream.
+// Called after metadata deserialization; Process p is already reconstructed.
+Status<std::shared_ptr<Process>> RestoreFromScatterStream(
+    VectoredReader &in, std::shared_ptr<Process> p) {
+  Time t0 = Time::Now();
+
+  // Read MigrateHeader.
+  MigrateHeader hdr{};
+  {
+    iovec iov = {&hdr, sizeof(hdr)};
+    if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
+      return MakeError(ret);
+  }
+  LOG(INFO) << "scatter receiver: " << hdr.segment_count << " segments";
+
+  // Read all segment descriptors.
+  std::vector<MigrateSegment> segs(hdr.segment_count);
+  if (hdr.segment_count > 0) {
+    iovec iov = {segs.data(), segs.size() * sizeof(MigrateSegment)};
+    if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
+      return MakeError(ret);
+  }
+
+  // Fake MemoryMap — the real one was restored by cereal.
+  MemoryMap mm(nullptr, kMemoryMappingSize);
+  mm.MarkAsFake();
+
+  // Phase 1: Pre-allocate kLoad segments and build scatter-read iovecs.
+  std::vector<iovec> load_iovs;
+  for (const auto &seg : segs) {
+    if (seg.type != kMigrateSegLoad) continue;
+    if (seg.memsz == 0) continue;
+
+    Status<void *> ret = mm.MMapAnonymous(
+        reinterpret_cast<void *>(seg.vaddr), seg.memsz,
+        PROT_READ | PROT_WRITE, MAP_FIXED);
+    if (!ret) {
+      LOG(ERR) << "scatter receiver: MMapAnonymous failed vaddr=0x" << std::hex
+               << seg.vaddr << " memsz=" << std::dec << seg.memsz;
+      return MakeError(ret);
+    }
+
+    if (seg.filesz > 0)
+      load_iovs.emplace_back(reinterpret_cast<void *>(seg.vaddr), seg.filesz);
+  }
+
+  // Phase 2: Single scatter-read for all kLoad data.
+  if (!load_iovs.empty()) {
+    if (Status<void> ret = ReadvFull(in, load_iovs); !ret) {
+      LOG(ERR) << "scatter receiver: scatter-read failed";
+      return MakeError(ret);
+    }
+  }
+  Time t1 = Time::Now();
+  size_t data_bytes = 0;
+  for (const auto &iov : load_iovs) data_bytes += iov.iov_len;
+  LOG(INFO) << "scatter receiver: data transfer took "
+            << (t1 - t0).Microseconds() << " us (" << data_bytes << " bytes)";
+
+  // Phase 3: Zero BSS gaps and set final protections.
+  for (const auto &seg : segs) {
+    if (seg.type != kMigrateSegLoad || seg.memsz == 0) continue;
+
+    // Zero partial page between filesz and page-aligned end.
+    if (seg.filesz < seg.memsz) {
+      uintptr_t file_end = seg.vaddr + seg.filesz;
+      uintptr_t gap_end = PageAlign(file_end);
+      if (gap_end > file_end && gap_end <= seg.vaddr + seg.memsz)
+        std::memset(reinterpret_cast<void *>(file_end), 0, gap_end - file_end);
+    }
+
+    // Set final protection if different from RW.
+    int final_prot = static_cast<int>(seg.prot);
+    if (final_prot != (PROT_READ | PROT_WRITE)) {
+      Status<void> ret = mm.MProtect(reinterpret_cast<void *>(seg.vaddr),
+                                     seg.memsz, final_prot);
+      if (!ret) {
+        LOG(ERR) << "scatter receiver: MProtect failed vaddr=0x" << std::hex
+                 << seg.vaddr;
+        return MakeError(ret);
+      }
+    }
+  }
+
+  // Phase 4: Handle kFileRef segments.
+  for (const auto &seg : segs) {
+    if (seg.type != kMigrateSegFileRef) continue;
+
+    std::vector<char> pathbuf(seg.filesz);
+    {
+      iovec iov = {pathbuf.data(), pathbuf.size()};
+      if (Status<void> ret = ReadvFull(in, {&iov, 1}); !ret)
+        return MakeError(ret);
+    }
+    std::string_view path(pathbuf.data(), seg.filesz - 1);
+
+    LOG(DEBUG) << "scatter receiver: FileRef path=" << path << " vaddr=0x"
+               << std::hex << seg.vaddr << " memsz=" << std::dec << seg.memsz
+               << " file_offset=0x" << std::hex << seg.file_offset;
+
+    Status<JunctionFile> ref =
+        JunctionFile::Open(p->get_fs(), path, 0, FileMode::kRead);
+    if (!ref) {
+      LOG(ERR) << "scatter receiver: FileRef failed to open " << path;
+      return MakeError(ref);
+    }
+
+    int prot = static_cast<int>(seg.prot);
+    if (Status<void> r = ref->MMapFixed(
+            mm, reinterpret_cast<void *>(seg.vaddr), seg.memsz, prot,
+            MAP_DENYWRITE, static_cast<off_t>(seg.file_offset));
+        !r) {
+      LOG(ERR) << "scatter receiver: FileRef MMapFixed failed for " << path;
+      return MakeError(r);
+    }
+  }
+
+  // Phase 5: Optionally populate pages.
+  if (GetCfg().restore_populate()) {
+    mm.ForEachVMA([](const VMArea &vma) {
+      if (!(vma.prot & PROT_READ)) return;
+      KernelMAdvise(vma.Addr(), vma.Length(), MADV_POPULATE_READ);
+    });
+  }
+
+  Time t2 = Time::Now();
+  LOG(INFO) << "scatter receiver: total restore took "
+            << (t2 - t0).Microseconds() << " us";
+
+  if (unlikely(GetCfg().mem_trace())) p->get_mem_map().EnableTracing(*p.get());
+
+  timings().migration_restore_done = Time::Now();
+  p->RunThreads();
+  return p;
+}
+
+}  // namespace junction

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -128,7 +128,7 @@ def cmd_initiator(port, scatter_copy):
     print("==> Final counter state on destination:")
     print(send_cmd(DST_IP, port, "GET"))
 
-    print(f"\n==> Downtime:             {downtime_us:.1f} us")
+    # print(f"\n==> Downtime:             {downtime_us:.1f} us")
     print(f"==> Total migration time: {total_us:.1f} us")
 
 

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -8,6 +8,10 @@ Usage:
   Node 0 (sender):    scripts/migrate.py sender <service_port>
   Node 1 (receiver):  scripts/migrate.py receiver
   Initiator:          scripts/migrate.py initiator <service_port>
+
+For kv_service (larger heap workload):
+  Node 0 (sender):    scripts/migrate.py sender 8080 --service kv --num-keys 10000 --value-size 1024
+  Initiator:          scripts/migrate.py initiator 8080 --service kv
 """
 
 import argparse
@@ -26,16 +30,17 @@ MIGRATION_BUILD_DIR = os.path.join(BUILD_DIR, "samples", "migration")
 SERVICE_CONFIG = os.path.join(MIGRATION_BUILD_DIR, "caladan_service.config")
 DST_CONFIG = os.path.join(MIGRATION_BUILD_DIR, "caladan_migration_dst.config")
 COUNTER_SVC = os.path.join(MIGRATION_BUILD_DIR, "counter_service")
+KV_SVC = os.path.join(MIGRATION_BUILD_DIR, "kv_service")
 
 SRC_IP = "10.10.1.1"
 DST_IP = "10.10.1.2"
 
 
 def send_cmd(ip, port, cmd, timeout=5):
-    """Send a command to counter_service and return the response."""
+    """Send a command to a service and return the response."""
     with socket.create_connection((ip, port), timeout=timeout) as s:
         s.sendall((cmd + "\n").encode())
-        return s.recv(64).decode().strip()
+        return s.recv(4096).decode().strip()
 
 
 def wait_for_service(ip, port, timeout=30):
@@ -56,9 +61,17 @@ def kill_leftover():
     time.sleep(1)
 
 
-def cmd_sender(port, skip_file_pages, verbose):
+def cmd_sender(port, skip_file_pages, verbose, service, num_keys, value_size):
     kill_leftover()
-    print(f"==> Starting counter_service on {SRC_IP}:{port}")
+    if service == "kv":
+        svc_bin = KV_SVC
+        svc_args = [str(port), str(num_keys), str(value_size)]
+        print(f"==> Starting kv_service on {SRC_IP}:{port} "
+              f"({num_keys} keys, {value_size} B each)")
+    else:
+        svc_bin = COUNTER_SVC
+        svc_args = [str(port)]
+        print(f"==> Starting counter_service on {SRC_IP}:{port}")
     loglevel = "6" if verbose else "5"
     cmd = [
         "sudo", "-E", JUNCTION_RUN, SERVICE_CONFIG, "--snapshot_enabled",
@@ -66,7 +79,7 @@ def cmd_sender(port, skip_file_pages, verbose):
     ]
     if skip_file_pages:
         cmd.append("--skip_file_pages")
-    cmd += ["--", COUNTER_SVC, str(port)]
+    cmd += ["--", svc_bin] + svc_args
     subprocess.run(cmd)
 
 
@@ -79,33 +92,22 @@ def cmd_receiver(verbose):
     subprocess.run(cmd)
 
 
-def cmd_initiator(port, scatter_copy):
-    # Increment counter on source
-    print(f"==> Incrementing counter on source ({SRC_IP}):")
-    for _ in range(3):
-        print(send_cmd(SRC_IP, port, "INC"))
-    print("==> Counter state before migration:")
-    print(send_cmd(SRC_IP, port, "GET"))
-
-    # Get PID
+def do_migrate(port, scatter_copy):
+    """Trigger migration and return total migration time in us."""
     pid = subprocess.check_output(
         [JUNCTION_CTL, SRC_IP, "ps"]
     ).decode().strip().strip("[]").split(",")[0].strip()
     print(f"==> Migrating pid={pid} from {SRC_IP} to {DST_IP}:44")
 
-    # Trigger migration and measure
     t_start = time.perf_counter()
     migrate_cmd = [JUNCTION_CTL, SRC_IP, "migrate"]
     if scatter_copy:
         migrate_cmd.append("--scatter-copy")
     migrate_cmd += [pid, DST_IP, "44"]
     subprocess.run(migrate_cmd, check=True)
-    t_src_down = time.perf_counter()
 
-    # Wait for destination to be ready
     t_dst_up = wait_for_service(DST_IP, port)
-    wait_us = (t_dst_up - t_src_down) * 1e6
-    print(f"==> wait_for_service took: {wait_us:.1f} us")
+    total_us = (t_dst_up - t_start) * 1e6
 
     # Verify source is down
     print("==> Verifying source is no longer serving (expect error):")
@@ -115,21 +117,52 @@ def cmd_initiator(port, scatter_copy):
     except OSError:
         print("==> Source confirmed down.")
 
-    downtime_us = (t_dst_up - t_src_down) * 1e6
-    total_us = (t_dst_up - t_start) * 1e6
+    return total_us
+
+
+def cmd_initiator_counter(port, scatter_copy):
+    print(f"==> Incrementing counter on source ({SRC_IP}):")
+    for _ in range(3):
+        print(send_cmd(SRC_IP, port, "INC"))
+    print("==> Counter state before migration:")
+    print(send_cmd(SRC_IP, port, "GET"))
+
+    total_us = do_migrate(port, scatter_copy)
 
     print("==> Counter state on destination:")
     print(send_cmd(DST_IP, port, "GET"))
-
-    # Verify counter continues incrementing on destination
     print("==> Incrementing counter on destination:")
     for _ in range(3):
         print(send_cmd(DST_IP, port, "INC"))
     print("==> Final counter state on destination:")
     print(send_cmd(DST_IP, port, "GET"))
 
-    # print(f"\n==> Downtime:             {downtime_us:.1f} us")
-    print(f"==> Total migration time: {total_us:.1f} us")
+    print(f"\n==> Total migration time: {total_us:.1f} us")
+
+
+def cmd_initiator_kv(port, scatter_copy):
+    print(f"==> KV store stats on source ({SRC_IP}):")
+    print(send_cmd(SRC_IP, port, "STATS"))
+    pre_cksum = send_cmd(SRC_IP, port, "CHECKSUM")
+    print(f"==> Checksum before migration: {pre_cksum}")
+
+    total_us = do_migrate(port, scatter_copy)
+
+    print("==> KV store stats on destination:")
+    print(send_cmd(DST_IP, port, "STATS"))
+    post_cksum = send_cmd(DST_IP, port, "CHECKSUM")
+    print(f"==> Checksum after migration:  {post_cksum}")
+
+    if pre_cksum == post_cksum:
+        print("==> CHECKSUM MATCH — state preserved correctly")
+    else:
+        print("==> CHECKSUM MISMATCH — data corruption detected!")
+
+    print("==> Writing new key on destination:")
+    print(send_cmd(DST_IP, port, "SET test_key hello_from_dst"))
+    print(send_cmd(DST_IP, port, "GET test_key"))
+
+    print(f"\n==> Total migration time: {total_us:.1f} us")
 
 
 def main():
@@ -137,23 +170,39 @@ def main():
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("-v", action="store_true", help="verbose logging")
     sub = parser.add_subparsers(dest="role", required=True)
+
     s = sub.add_parser("sender")
     s.add_argument("port", type=int)
     s.add_argument("--skip-file-pages", action="store_true",
                    help="skip file-backed read-only pages during migration")
+    s.add_argument("--service", choices=["counter", "kv"], default="counter",
+                   help="service to run (default: counter)")
+    s.add_argument("--num-keys", type=int, default=10000,
+                   help="number of keys to pre-load (kv only, default: 10000)")
+    s.add_argument("--value-size", type=int, default=1024,
+                   help="value size in bytes (kv only, default: 1024)")
+
     sub.add_parser("receiver")
+
     i = sub.add_parser("initiator")
     i.add_argument("port", type=int)
     i.add_argument("--scatter-copy", action="store_true",
                    help="use scatter-copy migration instead of ELF format")
+    i.add_argument("--service", choices=["counter", "kv"], default="counter",
+                   help="service being migrated (default: counter)")
+
     args = parser.parse_args()
 
     if args.role == "sender":
-        cmd_sender(args.port, getattr(args, "skip_file_pages", False), args.v)
+        cmd_sender(args.port, args.skip_file_pages, args.v,
+                   args.service, args.num_keys, args.value_size)
     elif args.role == "receiver":
         cmd_receiver(args.v)
     elif args.role == "initiator":
-        cmd_initiator(args.port, getattr(args, "scatter_copy", False))
+        if args.service == "kv":
+            cmd_initiator_kv(args.port, args.scatter_copy)
+        else:
+            cmd_initiator_counter(args.port, args.scatter_copy)
 
 
 if __name__ == "__main__":

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -5,9 +5,9 @@ Requires: scripts/build.sh (to build migration samples)
 Requires: iokerneld already running on each node (see README)
 
 Usage:
-  Node 0 (sender):    scripts/migrate.py sender <service_port>
-  Node 1 (receiver):  scripts/migrate.py receiver
-  Initiator:          scripts/migrate.py initiator <service_port>
+  Node 0 (sender):    scripts/migrate.py sender <port> [--src-ip IP --dst-ip IP]
+  Node 1 (receiver):  scripts/migrate.py receiver [--src-ip IP --dst-ip IP]
+  Initiator:          scripts/migrate.py initiator <port> [--src-ip IP --dst-ip IP]
 
 For kv_service (larger heap workload):
   Node 0 (sender):    scripts/migrate.py sender 8080 --service kv --num-keys 10000 --value-size 1024
@@ -19,6 +19,7 @@ import os
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -27,13 +28,32 @@ BUILD_DIR = os.path.join(ROOT_DIR, "build", "junction")
 JUNCTION_RUN = os.path.join(BUILD_DIR, "junction_run")
 JUNCTION_CTL = os.path.join(ROOT_DIR, "build", "junction-ctl", "junction-ctl")
 MIGRATION_BUILD_DIR = os.path.join(BUILD_DIR, "samples", "migration")
-SERVICE_CONFIG = os.path.join(MIGRATION_BUILD_DIR, "caladan_service.config")
-DST_CONFIG = os.path.join(MIGRATION_BUILD_DIR, "caladan_migration_dst.config")
 COUNTER_SVC = os.path.join(MIGRATION_BUILD_DIR, "counter_service")
 KV_SVC = os.path.join(MIGRATION_BUILD_DIR, "kv_service")
 
-SRC_IP = "10.10.1.1"
-DST_IP = "10.10.1.2"
+DEFAULT_SRC_IP = "10.10.1.1"
+DEFAULT_DST_IP = "10.10.1.2"
+
+CALADAN_CONFIG_COMMON = """\
+host_netmask 255.255.255.0
+runtime_kthreads 4
+runtime_spinning_kthreads 0
+runtime_guaranteed_kthreads 4
+runtime_priority lc
+runtime_quantum_us 0"""
+
+SRC_IP = DEFAULT_SRC_IP
+DST_IP = DEFAULT_DST_IP
+
+
+def generate_caladan_config(host_addr, host_gateway):
+    """Write a Caladan config to a temp file and return its path."""
+    content = f"host_addr {host_addr}\nhost_gateway {host_gateway}\n{CALADAN_CONFIG_COMMON}\n"
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".config",
+                                    prefix="caladan_", delete=False)
+    f.write(content)
+    f.close()
+    return f.name
 
 
 def send_cmd(ip, port, cmd, timeout=5):
@@ -63,6 +83,7 @@ def kill_leftover():
 
 def cmd_sender(port, skip_file_pages, verbose, service, num_keys, value_size):
     kill_leftover()
+    config = generate_caladan_config(SRC_IP, DST_IP)
     if service == "kv":
         svc_bin = KV_SVC
         svc_args = [str(port), str(num_keys), str(value_size)]
@@ -74,22 +95,29 @@ def cmd_sender(port, skip_file_pages, verbose, service, num_keys, value_size):
         print(f"==> Starting counter_service on {SRC_IP}:{port}")
     loglevel = "6" if verbose else "5"
     cmd = [
-        "sudo", "-E", JUNCTION_RUN, SERVICE_CONFIG, "--snapshot_enabled",
+        "sudo", "-E", JUNCTION_RUN, config, "--snapshot_enabled",
         "--loglevel", loglevel,
     ]
     if skip_file_pages:
         cmd.append("--skip_file_pages")
     cmd += ["--", svc_bin] + svc_args
-    subprocess.run(cmd)
+    try:
+        subprocess.run(cmd)
+    finally:
+        os.unlink(config)
 
 
 def cmd_receiver(verbose):
     kill_leftover()
+    config = generate_caladan_config(DST_IP, SRC_IP)
     print("==> Migration server listening on port 44")
     loglevel = "6" if verbose else "5"
-    cmd = ["sudo", "-E", JUNCTION_RUN, DST_CONFIG, "--snapshot_enabled",
+    cmd = ["sudo", "-E", JUNCTION_RUN, config, "--snapshot_enabled",
            "--loglevel", loglevel]
-    subprocess.run(cmd)
+    try:
+        subprocess.run(cmd)
+    finally:
+        os.unlink(config)
 
 
 def do_migrate(port, scatter_copy):
@@ -165,6 +193,13 @@ def cmd_initiator_kv(port, scatter_copy):
     print(f"\n==> Total migration time: {total_us:.1f} us")
 
 
+def add_ip_args(parser):
+    parser.add_argument("--src-ip", default=DEFAULT_SRC_IP,
+                        help=f"source node IP (default: {DEFAULT_SRC_IP})")
+    parser.add_argument("--dst-ip", default=DEFAULT_DST_IP,
+                        help=f"destination node IP (default: {DEFAULT_DST_IP})")
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__,
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -173,6 +208,7 @@ def main():
 
     s = sub.add_parser("sender")
     s.add_argument("port", type=int)
+    add_ip_args(s)
     s.add_argument("--skip-file-pages", action="store_true",
                    help="skip file-backed read-only pages during migration")
     s.add_argument("--service", choices=["counter", "kv"], default="counter",
@@ -182,16 +218,22 @@ def main():
     s.add_argument("--value-size", type=int, default=1024,
                    help="value size in bytes (kv only, default: 1024)")
 
-    sub.add_parser("receiver")
+    r = sub.add_parser("receiver")
+    add_ip_args(r)
 
     i = sub.add_parser("initiator")
     i.add_argument("port", type=int)
+    add_ip_args(i)
     i.add_argument("--scatter-copy", action="store_true",
                    help="use scatter-copy migration instead of ELF format")
     i.add_argument("--service", choices=["counter", "kv"], default="counter",
                    help="service being migrated (default: counter)")
 
     args = parser.parse_args()
+
+    global SRC_IP, DST_IP
+    SRC_IP = args.src_ip
+    DST_IP = args.dst_ip
 
     if args.role == "sender":
         cmd_sender(args.port, args.skip_file_pages, args.v,

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -79,7 +79,7 @@ def cmd_receiver(verbose):
     subprocess.run(cmd)
 
 
-def cmd_initiator(port):
+def cmd_initiator(port, scatter_copy):
     # Increment counter on source
     print(f"==> Incrementing counter on source ({SRC_IP}):")
     for _ in range(3):
@@ -95,8 +95,10 @@ def cmd_initiator(port):
 
     # Trigger migration and measure
     t_start = time.perf_counter()
-    subprocess.run([JUNCTION_CTL, SRC_IP, "migrate", pid, DST_IP, "44"],
-                   check=True)
+    migrate_cmd = [JUNCTION_CTL, SRC_IP, "migrate", pid, DST_IP, "44"]
+    if scatter_copy:
+        migrate_cmd.append("--scatter-copy")
+    subprocess.run(migrate_cmd, check=True)
     t_src_down = time.perf_counter()
 
     # Wait for destination to be ready
@@ -141,6 +143,8 @@ def main():
     sub.add_parser("receiver")
     i = sub.add_parser("initiator")
     i.add_argument("port", type=int)
+    i.add_argument("--scatter-copy", action="store_true",
+                   help="use scatter-copy migration instead of ELF format")
     args = parser.parse_args()
 
     if args.role == "sender":
@@ -148,7 +152,7 @@ def main():
     elif args.role == "receiver":
         cmd_receiver(args.v)
     elif args.role == "initiator":
-        cmd_initiator(args.port)
+        cmd_initiator(args.port, getattr(args, "scatter_copy", False))
 
 
 if __name__ == "__main__":

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -95,9 +95,10 @@ def cmd_initiator(port, scatter_copy):
 
     # Trigger migration and measure
     t_start = time.perf_counter()
-    migrate_cmd = [JUNCTION_CTL, SRC_IP, "migrate", pid, DST_IP, "44"]
+    migrate_cmd = [JUNCTION_CTL, SRC_IP, "migrate"]
     if scatter_copy:
         migrate_cmd.append("--scatter-copy")
+    migrate_cmd += [pid, DST_IP, "44"]
     subprocess.run(migrate_cmd, check=True)
     t_src_down = time.perf_counter()
 


### PR DESCRIPTION
### Summary

This PR introduces scatter-copy migration support and improves the overall migration workflow in Junction. It refactors snapshot logic into shared components, adds a new key-value service sample, and enhances the migration scripting with automatic Caladan config generation.

### Changes

Scatter-copy snapshot implementation
- Added snapshot_scatter.cc with a new scatter-copy migration path
- Added scatter_copy flag to junction-ctl and webctl to toggle the new mode
- Defined migrate_format.h for shared migration data structures

Snapshot refactoring
- Extracted shared migration logic from snapshot_elf.cc into a common header (snapshot.h)
- Simplified snapshot_elf.cc by reusing shared components
- Enabled DropUnusedStack functionality

ELF / stack handling fix
- Keep stack start address the same in ELF but use an offset on the restore side to place the stack correctly
- Added stricter checks on using physical addresses

Migration script improvements
- Rewrote scripts/migrate.py with automatic source/destination IP and Caladan config generation
- Removed manual downtime step from the migration flow

New sample: kv_service
- Added kv_service.cc — a key-value service sample using only C APIs
- Integrated into the migration samples CMake build and migration script